### PR TITLE
Fix data File duplication

### DIFF
--- a/src/main/resources/graphql/crdc-ctdc-private-es.graphql
+++ b/src/main/resources/graphql/crdc-ctdc-private-es.graphql
@@ -172,8 +172,8 @@ type BiospecimenOverview {
   specimen_type: String
   tissue_category: String
   assessment_timepoint: String
-  data_file_uuid: String
-  data_files: [DataFile] # For Adding Files into Cart
+  data_file_uuid: [String] # For Adding Files into Cart
+  data_files: [DataFile]
 }
 
 type FileOverview {

--- a/src/main/resources/graphql/crdc-ctdc-private-es.graphql
+++ b/src/main/resources/graphql/crdc-ctdc-private-es.graphql
@@ -372,6 +372,7 @@ type QueryType {
   fileIDsFromList(
     subject_id: [String] = []
     specimen_id: [String] = []
+    data_file_uuid: [String] = []
     data_file_name: [String] = []
   ): [String]
 

--- a/src/main/resources/yaml/single_search_es.yml
+++ b/src/main/resources/yaml/single_search_es.yml
@@ -92,11 +92,12 @@ queries:
       - tab_data_files
     filter:
       type: default
-      caseInsensitive: true
+      # caseInsensitive: true
       selectedField: data_file_uuid
       ignoreIfEmpty:
         - subject_id
         - specimen_id
+        - data_file_uuid
         - data_file_name
     result:
       type: str_array


### PR DESCRIPTION
In this PR:
- User can add file using `data_file_uuid` instead of `data_file_name`
- Convert `data_file_uuid` into object under Biospecimen