### PR TITLE
Update age_at_enrollment and numberOfTargetedTherapies

### DIFF
--- a/src/main/resources/graphql/crdc-ctdc-private-es.graphql
+++ b/src/main/resources/graphql/crdc-ctdc-private-es.graphql
@@ -1,106 +1,100 @@
-
-
 type GlobalSearchResult {
+  participants: [GS_Subject]
+  participant_count: Int
 
-    participants: [GS_Subject]
-    participant_count: Int
+  biospecimens: [GS_Biospecimen]
+  biospecimen_count: Int
 
-    biospecimens: [GS_Biospecimen]
-    biospecimen_count: Int
+  about_count: Int
+  about_page: [GS_About]
 
-    about_count: Int
-    about_page: [GS_About]
+  model_count: Int
+  model: [GS_Model]
 
-    model_count: Int
-    model: [GS_Model]
-
-    gs_list: [GS_list]
- 
+  gs_list: [GS_list]
 }
 
 type GS_list {
-    autocomplete_list: String
+  autocomplete_list: String
 }
 
 type PublicGlobalSearchResult {
+  about_count: Int
+  about_page: [GS_About]
 
-    about_count: Int
-    about_page: [GS_About]
-
-    model_count: Int
-    model: [GS_Model]
+  model_count: Int
+  model: [GS_Model]
 }
 type GS_Program {
-    type: String
-    program_id: String
-    program_code: String
-    program_name: String
+  type: String
+  program_id: String
+  program_code: String
+  program_name: String
 }
 
 type GS_Study {
-    type: String
-    study_id: String
-    program_id: String
-    study_name: String
-    study_type: String
-    study_code: String
+  type: String
+  study_id: String
+  program_id: String
+  study_name: String
+  study_type: String
+  study_code: String
 }
 
 type GS_Subject {
-    type: String
-    study_short_name: String
-    ctep_disease_term: String
-    sex: String
-    reported_gender: String
-    race: String
-    targeted_therapy: String
-    ethnicity: String
-    subject_id: String
-    stage_of_disease: String
-    age_at_enrollment: String
+  type: String
+  study_short_name: String
+  ctep_disease_term: String
+  sex: String
+  reported_gender: String
+  race: String
+  targeted_therapy: String
+  ethnicity: String
+  subject_id: String
+  stage_of_disease: String
+  age_at_enrollment: Int
 }
 
 type GS_Biospecimen {
-    type: String
-    study_short_name: String
-    parent_specimen_id: String
-    specimen_id: String
-    subject_id: String
-    ctep_disease_term: String
-    specimen_type: String
-    parent_specimen_type: String
-    tissue_category: String
-    anatomical_collection_site: String
-    assessment_timepoint: String  
-    
+  type: String
+  study_short_name: String
+  parent_specimen_id: String
+  specimen_id: String
+  subject_id: String
+  ctep_disease_term: String
+  specimen_type: String
+  parent_specimen_type: String
+  tissue_category: String
+  anatomical_collection_site: String
+  assessment_timepoint: String
 }
 
 type GS_File {
-    type: String
-    file_id: String
-    file_name: String
-    file_format: String
-    program_id: String
-    subject_id: String
-    sample_id: String
+  type: String
+  file_id: String
+  file_name: String
+  file_format: String
+  program_id: String
+  subject_id: String
+  sample_id: String
 }
 
 type GS_Model {
-    type: String
-    node_name: String
-    property_name: String
-    property_description: String
-    property_required: String
-    property_type: String
-    value: String
-    highlight: String
+  type: String
+  node_name: String
+  property_name: String
+  property_description: String
+  property_required: String
+  property_type: String
+  value: String
+  highlight: String
 }
 
 type GS_About {
-    page: String
-    title: String
-    type: String
-    text: [String]
+  page: String
+  title: String
+  type: String
+  text: [String]
 }
 
 type Subject {
@@ -564,9 +558,9 @@ type QueryType {
     offset: Int = 0
   ): [FileOverview]
 
-  globalSearch (
-    input: String,
-    first: Int = 100,
+  globalSearch(
+    input: String
+    first: Int = 100
     offset: Int = 0
   ): GlobalSearchResult
 }

--- a/src/main/resources/yaml/facet_search_es.yml
+++ b/src/main/resources/yaml/facet_search_es.yml
@@ -77,7 +77,7 @@ queries:
           - widgets_facets_counts
         filter:
           type: aggregation
-          selectedField: targeted_therapy_id
+          selectedField: targeted_therapy
         result:
           type: int
           method: count_bucket_keys


### PR DESCRIPTION
In this PR:
- Converted `age_at_enrollment` from `String` to `Int`.
- Updated `numberOfTargetedTherapies` to be counted by `targeted_therapy` instead of `targeted_therapy_id`. This change will reduce the existing data count from 657 to 44, matching the Targeted Therapy count displayed on the Home page."