### PR TITLE
Change fragmentsize to 25 for global search

### DIFF
--- a/src/main/resources/yaml/global_search_es.yml
+++ b/src/main/resources/yaml/global_search_es.yml
@@ -187,6 +187,7 @@ queries:
         highlight:
           fields:
             - content.paragraph
+          fragmentSize: 25
           preTag: $
           postTag: $
         result:


### PR DESCRIPTION
Change fragment size to 25 for global search so results are better for the global search general tab.
https://tracker.nci.nih.gov/browse/CTDC-1514