### PR TITLE
Upgrade to Java 21 and Tomcat 10.1.55

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,8 @@ RUN mvn package -DskipTests
 FROM tomcat:10.1.55-jdk21-temurin AS fnl_base_image
 ENV JAVA_OPTS="-Xmx4096m"
 
-RUN apt-get update && apt-get -y upgrade \
-	&& apt-get install -y unzip \
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends unzip \
 	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/local/tomcat/webapps.dist \
 	&& rm -rf /usr/local/tomcat/webapps/ROOT

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN mvn package -DskipTests
 # RUN rm -rf /usr/local/tomcat/webapps/ROOT
 
 FROM tomcat:10.1.55-jdk21-temurin AS fnl_base_image
-ENV JAVA_OPTS="-Xmx4096m"
+ENV JAVA_OPTS="-XX:InitialRAMPercentage=25.0 -XX:MaxRAMPercentage=75.0"
 
 RUN apt-get update \
 	&& apt-get install -y --no-install-recommends unzip \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Build stage
 ARG ECR_REPO
-FROM maven:3.8.5-openjdk-17 as build
+FROM maven:3.9.9-eclipse-temurin-21 AS build
 WORKDIR /usr/src/app
 
 # Copy only git related files first
@@ -21,14 +21,14 @@ RUN mvn package -DskipTests
 # RUN rm -rf /usr/local/tomcat/webapps.dist
 # RUN rm -rf /usr/local/tomcat/webapps/ROOT
 
-FROM tomcat:10.1.54-jdk17 AS fnl_base_image
+FROM tomcat:10.1.55-jdk21-temurin AS fnl_base_image
+ENV JAVA_OPTS="-Xmx4096m"
 
-RUN apt-get update && apt-get -y upgrade
-
-# install dependencies and clean up unused files
-RUN apt-get update && apt-get install unzip
-RUN rm -rf /usr/local/tomcat/webapps.dist
-RUN rm -rf /usr/local/tomcat/webapps/ROOT
+RUN apt-get update && apt-get -y upgrade \
+	&& apt-get install -y unzip \
+	&& rm -rf /var/lib/apt/lists/* \
+	&& rm -rf /usr/local/tomcat/webapps.dist \
+	&& rm -rf /usr/local/tomcat/webapps/ROOT
 
 # Modify the server.xml file to block error reportiing
 RUN sed -i 's|</Host>|  <Valve className="org.apache.catalina.valves.ErrorReportValve"\n               showReport="false"\n               showServerInfo="false" />\n\n      </Host>|' conf/server.xml 

--- a/pom.xml
+++ b/pom.xml
@@ -25,10 +25,13 @@
         <java.version>17</java.version>
         <jackson.version>2.18.7</jackson.version>
         <kotlin.version>1.9.25</kotlin.version>
+        <tomcat.version>10.1.55</tomcat.version>
+        <lombok.version>1.18.34</lombok.version>
         <log4j2.version>2.25.4</log4j2.version>
         <spring-framework.version>6.2.18</spring-framework.version>
         <spring.restdocs.version>3.0.1</spring.restdocs.version>
 	    <snakeyaml.version>2.0</snakeyaml.version>
+        <netty.version>4.1.133.Final</netty.version>
     </properties>
 
     <dependencies>
@@ -141,7 +144,7 @@
         <dependency>
             <groupId>org.apache.tomcat.embed</groupId>
             <artifactId>tomcat-embed-core</artifactId>
-            <version>10.1.54</version>
+            <version>${tomcat.version}</version>
         </dependency>
         <!-- JUnit -->
         <dependency>
@@ -271,7 +274,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.22</version>
+            <version>${lombok.version}</version>
             <scope>provided</scope>
         </dependency>
         <!-- Jakarta -->
@@ -285,7 +288,7 @@
         <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
-            <version>20231013</version>
+            <version>20250107</version>
         </dependency>
     </dependencies>
 
@@ -317,7 +320,7 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>
-                <version>4.1.133.Final</version>
+                <version>${netty.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -145,6 +145,7 @@
             <groupId>org.apache.tomcat.embed</groupId>
             <artifactId>tomcat-embed-core</artifactId>
             <version>${tomcat.version}</version>
+            <scope>provided</scope>
         </dependency>
         <!-- JUnit -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
 
     <properties>
-        <java.version>17</java.version>
+        <java.version>21</java.version>
         <jackson.version>2.18.7</jackson.version>
         <kotlin.version>1.9.25</kotlin.version>
         <tomcat.version>10.1.55</tomcat.version>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,6 +6,7 @@ auth.enabled= false
 auth.endpoint=
 
 #Spring
+spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.neo4j.Neo4jAutoConfiguration
 spring.mvc.throw-exception-if-no-handler-found=true
 spring.mvc.view.prefix=/WEB-INF/
 spring.mvc.view.suffix=.jsp


### PR DESCRIPTION
Update Dockerfile to use maven:3.9.9-eclipse-temurin-21 and tomcat:10.1.55-jdk21-temurin, set JAVA_OPTS (-Xmx4096m), combine apt-get steps, install unzip, and clean apt lists to reduce image size. pom.xml: add tomcat.version, lombok.version and netty.version properties; bump tomcat-embed-core, lombok and json versions and reference the netty BOM via property to centralize version management. application.properties: exclude Neo4j autoconfiguration (spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.neo4j.Neo4jAutoConfiguration). These changes modernize the runtime, centralize dependency versions, and optimize the container build.

Ticket: [CTDC-2009](https://tracker.nci.nih.gov/browse/CTDC-2009)