### PR TITLE
CTDC-2058: Retrieving all datafiles from participants and Specimens with ability to filter by associations 

### DIFF
--- a/src/main/resources/graphql/crdc-ctdc-private-es.graphql
+++ b/src/main/resources/graphql/crdc-ctdc-private-es.graphql
@@ -274,7 +274,7 @@ type AssocDataFile {
   data_file_checksum_type: String
   data_file_compression_status: String
   data_file_location: String
-  association: String
+  association: [String]
 }
 
 type StudyDataFile {

--- a/src/main/resources/graphql/crdc-ctdc-private-es.graphql
+++ b/src/main/resources/graphql/crdc-ctdc-private-es.graphql
@@ -263,11 +263,31 @@ type DataFile {
   data_file_location: String
 }
 
+type AssocDataFile {
+  data_file_uuid: String
+  data_file_name: String
+  data_file_type: String
+  data_file_description: String
+  data_file_format: String
+  data_file_size: Float
+  data_file_checksum_value: String
+  data_file_checksum_type: String
+  data_file_compression_status: String
+  data_file_location: String
+  association: String
+}
+
 type StudyDataFile {
   study_short_name: String
   list_type: [String]
   study_data_files: [DataFile]
   data_files: [DataFile]
+}
+
+type StudyDataFileAssoc {
+  study_short_name: String
+  list_type: [String]
+  data_files: [AssocDataFile]
 }
 
 type StudyZipFile {
@@ -747,7 +767,7 @@ type QueryType {
   study_data_file_assoc(
     study_short_name: [String] = [],
     study_id: [String] = []
-  ): [StudyDataFile]
+  ): [StudyDataFileAssoc]
 
   studyZipFileQuery(
     study_short_name: [String] = [],

--- a/src/main/resources/graphql/crdc-ctdc-private-es.graphql
+++ b/src/main/resources/graphql/crdc-ctdc-private-es.graphql
@@ -284,7 +284,7 @@ type StudyDataFile {
   data_files: [DataFile]
 }
 
-type StudyDataFileAssoc {
+type ParticipantAndBiospecimenFilesByStudyId {
   study_short_name: String
   list_type: [String]
   data_files: [AssocDataFile]
@@ -764,10 +764,10 @@ type QueryType {
     study_id: [String] = []
   ): [StudyDataFile]
 
-  study_data_file_assoc(
+  participantAndBiospecimenFilesByStudyId(
     study_short_name: [String] = [],
     study_id: [String] = []
-  ): [StudyDataFileAssoc]
+  ): [ParticipantAndBiospecimenFilesByStudyId]
 
   studyZipFileQuery(
     study_short_name: [String] = [],

--- a/src/main/resources/graphql/crdc-ctdc-private-es.graphql
+++ b/src/main/resources/graphql/crdc-ctdc-private-es.graphql
@@ -744,6 +744,11 @@ type QueryType {
     study_id: [String] = []
   ): [StudyDataFile]
 
+  study_data_file_assoc(
+    study_short_name: [String] = [],
+    study_id: [String] = []
+  ): [StudyDataFile]
+
   studyZipFileQuery(
     study_short_name: [String] = [],
     study_id: [String] = [],

--- a/src/main/resources/graphql/crdc-ctdc-private-es.graphql
+++ b/src/main/resources/graphql/crdc-ctdc-private-es.graphql
@@ -288,6 +288,7 @@ type ParticipantAndBiospecimenFilesByStudyId {
   study_short_name: String
   list_type: [String]
   data_files: [AssocDataFile]
+}
 type StudyFileTabInfo {
   type: String
   study_short_name: String
@@ -827,6 +828,8 @@ type QueryType {
     study_short_name: [String] = [],
     study_id: [String] = []
   ): [ParticipantAndBiospecimenFilesByStudyId]
+
+  
   StudyFileTabByStudyShortName(
     study_short_name: [String] = [],
     study_id: [String] = [],

--- a/src/main/resources/yaml/es_indices_ctdc.yml
+++ b/src/main/resources/yaml/es_indices_ctdc.yml
@@ -203,6 +203,84 @@ Indices:
                 }) AS data_files,
          COLLECT(DISTINCT df.data_file_type) as list_type
       "
+
+  - index_name: study_data_file_assoc
+    type: neo4j
+    mapping:
+      study_short_name:
+        type: keyword
+      study_id:
+        type: keyword
+      study_data_files:
+        type: nested
+        properties: {}
+      data_files:
+        type: nested
+        properties:
+          data_file_uuid:
+            type: keyword
+          data_file_name:
+            type: keyword
+          data_file_type:
+            type: keyword
+          data_file_description:
+            type: keyword
+          data_file_format:
+            type: keyword
+          data_file_size:
+            type: double
+          data_file_checksum_value:
+            type: keyword
+          data_file_checksum_type:
+            type: keyword
+          data_file_compression_status:
+            type: keyword
+          data_file_location:
+            type: keyword
+          association:
+            type: keyword
+      list_type:
+        type: keyword
+
+    cypher_query: "
+      MATCH (s:study)<-[:belongs_to]-(sb:participant)
+      OPTIONAL MATCH (sb)<-[*..2]-(df:file)
+
+      OPTIONAL MATCH (sb)<-[p_rel:associated_with]-(df)
+      OPTIONAL MATCH (df)-[b_rel:associated_with]->(:specimen)-[:of_participant]->(sb)
+
+      WITH s, sb, df, p_rel, b_rel
+      WITH s, sb, df,
+      [a IN [
+      CASE WHEN p_rel IS NOT NULL THEN 'participant' END,
+      CASE WHEN b_rel IS NOT NULL THEN 'biospecimen' END
+      ] WHERE a IS NOT NULL] AS associations
+
+      RETURN DISTINCT
+      s.study_short_name AS study_short_name,
+      s.study_id AS study_id,
+      [] AS study_data_files,
+      [x IN COLLECT(DISTINCT
+      CASE
+      WHEN df IS NULL THEN NULL
+      ELSE {
+      data_file_uuid: df.data_file_uuid,
+      data_file_name: df.data_file_name,
+      data_file_type: df.data_file_type,
+      data_file_description: df.data_file_description,
+      data_file_format: df.data_file_format,
+      data_file_size: df.data_file_size,
+      data_file_checksum_value: df.data_file_checksum_value,
+      data_file_checksum_type: df.data_file_checksum_type,
+      data_file_compression_status: df.data_file_compression_status,
+      data_file_location: df.data_file_location,
+      association: associations
+      }
+      END
+      ) WHERE x IS NOT NULL] AS data_files,
+      [t IN COLLECT(DISTINCT df.data_file_type) WHERE t IS NOT NULL] AS list_type
+      "
+
   # Name of the index to be created, existing index with same name will be deleted
   - index_name: study_zip_file
     type: neo4j

--- a/src/main/resources/yaml/es_indices_ctdc.yml
+++ b/src/main/resources/yaml/es_indices_ctdc.yml
@@ -256,7 +256,6 @@ Indices:
       RETURN DISTINCT
       s.study_short_name AS study_short_name,
       s.study_id AS study_id,
-      [] AS study_data_files,
       [x IN COLLECT(DISTINCT
       CASE
       WHEN df IS NULL THEN NULL

--- a/src/main/resources/yaml/es_indices_ctdc.yml
+++ b/src/main/resources/yaml/es_indices_ctdc.yml
@@ -211,9 +211,6 @@ Indices:
         type: keyword
       study_id:
         type: keyword
-      study_data_files:
-        type: nested
-        properties: {}
       data_files:
         type: nested
         properties:

--- a/src/main/resources/yaml/single_search_es.yml
+++ b/src/main/resources/yaml/single_search_es.yml
@@ -51,7 +51,7 @@ queries:
         - study_id
     result:
       type: object_array
-  - name: study_data_file_assoc
+  - name: participantAndBiospecimenFilesByStudyId
     index:
       - study_data_file_assoc
     filter:

--- a/src/main/resources/yaml/single_search_es.yml
+++ b/src/main/resources/yaml/single_search_es.yml
@@ -54,6 +54,14 @@ queries:
   - name: participantAndBiospecimenFilesByStudyId
     index:
       - study_data_file_assoc
+    filter:
+      type: default
+      caseInsensitive: false
+      ignoreIfEmpty:
+        - study_short_name
+        - study_id
+    result:
+      type: object_array
   - name: StudyFileTabByStudyShortName
     index:
       - study_file_tab

--- a/src/main/resources/yaml/single_search_es.yml
+++ b/src/main/resources/yaml/single_search_es.yml
@@ -51,6 +51,17 @@ queries:
         - study_id
     result:
       type: object_array
+  - name: study_data_file_assoc
+    index:
+      - study_data_file_assoc
+    filter:
+      type: default
+      caseInsensitive: false
+      ignoreIfEmpty:
+        - study_short_name
+        - study_id
+    result:
+      type: object_array
   - name: studyZipFileQuery
     index:
       - study_zip_file


### PR DESCRIPTION
The recent commits add a new study_data_file_assoc index, update the related GraphQL and YAML mappings to include association details on data files, clean up naming and query logic around that new index.

Retrieving all datafiles from participants and Specimens with ability to filter by associations 
ticket : https://tracker.nci.nih.gov/browse/CTDC-2058