### PR TITLE
Update GitHub Actions workflow for testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,5 @@
 name: Test
- 
+
 on:
   workflow_dispatch:
   push:
@@ -9,10 +9,10 @@ on:
   pull_request:
     branches:
       - "*"
- 
+
 permissions:
   contents: read
- 
+
 jobs:
   test:
     name: Test Changes
@@ -21,14 +21,14 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
         with:
-          submodules: 'recursive'
- 
-      - name: Set up JDK 17
+          submodules: "recursive"
+
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
-          distribution: 'temurin'
- 
+          java-version: "21"
+          distribution: "temurin"
+
       - name: Cache Maven packages
         uses: actions/cache@v4
         with:
@@ -37,17 +37,17 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
- 
+
       - name: Install dependencies & Test with Coverage
         run: mvn clean verify
- 
+
       - name: Archive Jacoco HTML report
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: jacoco-report
           path: target/site/jacoco/
- 
+
       - name: Coveralls GitHub Action
         # Only works if public and enabled in Coveralls, no token required
         uses: coverallsapp/github-action@v2


### PR DESCRIPTION

This pull request updates the GitHub Actions workflow to use JDK 21 instead of JDK 17. This ensures that all tests and builds run against the latest supported Java version updated under #170 
