### PR TITLE
Bump Netty to 4.2.14.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <spring-framework.version>6.2.18</spring-framework.version>
         <spring.restdocs.version>3.0.1</spring.restdocs.version>
 	    <snakeyaml.version>2.0</snakeyaml.version>
-        <netty.version>4.1.133.Final</netty.version>
+        <netty.version>4.2.14.Final</netty.version>
     </properties>
 
     <dependencies>
@@ -317,7 +317,7 @@
                 <artifactId>commons-logging</artifactId>
                 <version>1.2</version>
             </dependency>
-            <!-- Force Netty 4.1.133.Final to remediate CVE-2026-42583 -->
+            <!-- Force Netty 4.2.14.Final to remediate CVE-2026-42582/CVE-2026-42583 -->
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>


### PR DESCRIPTION
Update netty.version property from 4.1.133.Final to 4.2.14.Final and update the inline comment to reflect that the forced netty-bom now remediates CVE-2026-42582 and CVE-2026-42583. This ensures dependent Netty artifacts are resolved to the patched BOM version to address the security issues.