### PR TITLE
CTDC-2009: Upgrades system packages in the Dockerfile to address security vulnerabilities.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,11 +21,13 @@ RUN mvn package -DskipTests
 # RUN rm -rf /usr/local/tomcat/webapps.dist
 # RUN rm -rf /usr/local/tomcat/webapps/ROOT
 
-FROM tomcat:10.1.55-jdk21-temurin AS fnl_base_image
+FROM tomcat:10.1-jdk21-temurin AS fnl_base_image
 ENV JAVA_OPTS="-XX:InitialRAMPercentage=25.0 -XX:MaxRAMPercentage=75.0"
 
 RUN apt-get update \
 	&& DEBIAN_FRONTEND=noninteractive apt-get dist-upgrade -y \
+	&& DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends --only-upgrade util-linux tar libgcrypt20 libc-bin libc6 locales libexpat1 binutils xz-utils liblzma5 \
+	&& if apt-cache show libgnutls30t64 >/dev/null 2>&1; then DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends --only-upgrade libgnutls30t64; else DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends --only-upgrade libgnutls30; fi \
 	&& apt-get install -y --no-install-recommends unzip \
 	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/local/tomcat/webapps.dist \

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ FROM tomcat:10.1.55-jdk21-temurin AS fnl_base_image
 ENV JAVA_OPTS="-XX:InitialRAMPercentage=25.0 -XX:MaxRAMPercentage=75.0"
 
 RUN apt-get update \
+	&& DEBIAN_FRONTEND=noninteractive apt-get dist-upgrade -y \
 	&& apt-get install -y --no-install-recommends unzip \
 	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/local/tomcat/webapps.dist \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,12 @@ ARG ECR_REPO
 FROM maven:3.9.9-eclipse-temurin-21 AS build
 WORKDIR /usr/src/app
 
+# Refresh trust store in build image so Maven can resolve dependencies reliably.
+RUN apt-get update \
+	&& DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ca-certificates \
+	&& update-ca-certificates \
+	&& rm -rf /var/lib/apt/lists/*
+
 # Copy only git related files first
 COPY .gitmodules .
 COPY .git ./.git
@@ -21,12 +27,15 @@ RUN mvn package -DskipTests
 # RUN rm -rf /usr/local/tomcat/webapps.dist
 # RUN rm -rf /usr/local/tomcat/webapps/ROOT
 
-FROM tomcat:10.1-jdk21-temurin AS fnl_base_image
+FROM tomcat:10.1.55-jdk21-temurin AS fnl_base_image
 ENV JAVA_OPTS="-XX:InitialRAMPercentage=25.0 -XX:MaxRAMPercentage=75.0"
 
 RUN apt-get update \
 	&& DEBIAN_FRONTEND=noninteractive apt-get dist-upgrade -y \
 	&& DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends --only-upgrade util-linux tar libgcrypt20 libc-bin libc6 locales libexpat1 binutils xz-utils liblzma5 \
+	&& DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends --only-upgrade ca-certificates \
+	&& DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends --only-upgrade openssl \
+	&& if apt-cache show libssl3t64 >/dev/null 2>&1; then DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends --only-upgrade libssl3t64; else DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends --only-upgrade libssl3; fi \
 	&& if apt-cache show libgnutls30t64 >/dev/null 2>&1; then DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends --only-upgrade libgnutls30t64; else DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends --only-upgrade libgnutls30; fi \
 	&& apt-get install -y --no-install-recommends unzip \
 	&& rm -rf /var/lib/apt/lists/* \

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <spring-framework.version>6.2.18</spring-framework.version>
         <spring.restdocs.version>3.0.1</spring.restdocs.version>
 	    <snakeyaml.version>2.0</snakeyaml.version>
-        <netty.version>4.2.14.Final</netty.version>
+        <netty.version>4.2.15.Final</netty.version>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <tomcat.version>10.1.55</tomcat.version>
         <lombok.version>1.18.34</lombok.version>
         <log4j2.version>2.25.4</log4j2.version>
-        <spring-framework.version>6.2.18</spring-framework.version>
+        <spring-framework.version>6.2.19</spring-framework.version>
         <spring.restdocs.version>3.0.1</spring.restdocs.version>
 	    <snakeyaml.version>2.0</snakeyaml.version>
         <netty.version>4.2.15.Final</netty.version>


### PR DESCRIPTION
This PR updates the backend build/runtime to reduce CVE exposure and keep the image scan signal actionable. It upgrades Netty to 4.2.15.Final to fix CVE-2026-44249, refreshes the Tomcat runtime base and applies OS package upgrades during image build, and adds a temporary Trivy ignore file for upstream-unfixed OS CVEs with expiration dates. The CI Trivy scan is also updated to use the repo ignore file so the build only fails on newly introduced, actionable issues.

Ticket: [CTDC-2009](https://tracker.nci.nih.gov/browse/CTDC-2009)