### PR TITLE
Sync Publication GraphQL API from develop into 1.4.0

### DIFF
--- a/src/main/java/gov/nih/nci/bento_ri/model/PrivateESDataFetcher.java
+++ b/src/main/java/gov/nih/nci/bento_ri/model/PrivateESDataFetcher.java
@@ -25,6 +25,7 @@ import static graphql.schema.idl.TypeRuntimeWiring.newTypeWiring;
 @Component
 public class PrivateESDataFetcher extends AbstractPrivateESDataFetcher {
     private static final Logger logger = LogManager.getLogger(PrivateESDataFetcher.class);
+    private static final String STUDY_END_POINT = "/study/_search";
     private final YamlQueryFactory yamlQueryFactory;
     private final TypeMapperService typeMapper = new TypeMapperImpl();
 
@@ -60,6 +61,7 @@ public class PrivateESDataFetcher extends AbstractPrivateESDataFetcher {
                         })
                         .dataFetcher("samplesForSubjectId", env ->
                                 samplesForSubjectId(createQueryParam(env)))
+                        .dataFetcher("publicationInfo", env -> publicationInfo(env.getArguments()))
                 )
                 .build();
     }
@@ -340,4 +342,58 @@ public class PrivateESDataFetcher extends AbstractPrivateESDataFetcher {
         private static final String SAMPLE_NESTED_FILE_INFO = "file_info";
         private static final String FILES = "files";
     }
+
+    private List<Map<String, Object>> publicationInfo(Map<String, Object> params) throws IOException {
+        String[][] properties = new String[][]{
+                new String[]{"publications", "publications"}
+        };
+
+        Map<String, Object> filterParams = new HashMap<>();
+        filterParams.put("study_short_name", normalizeQueryValues(params.get("study_short_name")));
+        filterParams.put("study_id", normalizeQueryValues(params.get("study_id")));
+
+        List<Map<String, Object>> studies = esService.collectPage(filterParams, STUDY_END_POINT, properties);
+        List<Map<String, Object>> publications = new ArrayList<>();
+
+        for (Map<String, Object> study : studies) {
+            Object publicationsField = study.get("publications");
+            if (!(publicationsField instanceof List<?> publicationList)) {
+                continue;
+            }
+            for (Object publicationObj : publicationList) {
+                if (!(publicationObj instanceof Map<?, ?> publicationMap)) {
+                    continue;
+                }
+                Map<String, Object> publication = new HashMap<>();
+                publication.put("publication_title", publicationMap.get("publication_title"));
+                publication.put("authorship", publicationMap.get("authorship"));
+                publication.put("year_of_publication", publicationMap.get("year_of_publication"));
+                publication.put("journal_citation", publicationMap.get("journal_citation"));
+                publication.put("digital_object_id", publicationMap.get("digital_object_id"));
+                publication.put("pubmed_id", publicationMap.get("pubmed_id"));
+
+                if (publication.values().stream().anyMatch(Objects::nonNull)) {
+                    publications.add(publication);
+                }
+            }
+        }
+
+        return publications;
+    }
+
+    private List<String> normalizeQueryValues(Object value) {
+        if (value instanceof List<?> list && !list.isEmpty()) {
+            List<String> values = new ArrayList<>();
+            for (Object item : list) {
+                if (item != null) {
+                    values.add(item.toString());
+                }
+            }
+            if (!values.isEmpty()) {
+                return values;
+            }
+        }
+        return List.of("");
+    }
+
 }

--- a/src/main/java/gov/nih/nci/bento_ri/model/PrivateESDataFetcher.java
+++ b/src/main/java/gov/nih/nci/bento_ri/model/PrivateESDataFetcher.java
@@ -349,8 +349,14 @@ public class PrivateESDataFetcher extends AbstractPrivateESDataFetcher {
         };
 
         Map<String, Object> filterParams = new HashMap<>();
-        filterParams.put("study_short_name", normalizeQueryValues(params.get("study_short_name")));
-        filterParams.put("study_id", normalizeQueryValues(params.get("study_id")));
+        List<String> studyShortNames = normalizeQueryValues(params.get("study_short_name"));
+        if (!studyShortNames.isEmpty()) {
+            filterParams.put("study_short_name", studyShortNames);
+        }
+        List<String> studyIds = normalizeQueryValues(params.get("study_id"));
+        if (!studyIds.isEmpty()) {
+            filterParams.put("study_id", studyIds);
+        }
 
         List<Map<String, Object>> studies = esService.collectPage(filterParams, STUDY_END_POINT, properties);
         List<Map<String, Object>> publications = new ArrayList<>();
@@ -386,14 +392,17 @@ public class PrivateESDataFetcher extends AbstractPrivateESDataFetcher {
             List<String> values = new ArrayList<>();
             for (Object item : list) {
                 if (item != null) {
-                    values.add(item.toString());
+                    String str = item.toString().trim();
+                    if (!str.isEmpty()) {
+                        values.add(str);
+                    }
                 }
             }
             if (!values.isEmpty()) {
                 return values;
             }
         }
-        return List.of("");
+        return List.of();
     }
 
 }

--- a/src/main/resources/graphql/crdc-ctdc-private-es.graphql
+++ b/src/main/resources/graphql/crdc-ctdc-private-es.graphql
@@ -941,4 +941,9 @@ type QueryType {
     study_short_name: [String] = []
     study_id: [String] = []
   ): [ClinicalTrialData]
+
+  publicationInfo(
+    study_short_name: [String] = []
+    study_id: [String] = []
+  ): [Publication]
 }

--- a/src/main/resources/yaml/es_indices_ctdc.yml
+++ b/src/main/resources/yaml/es_indices_ctdc.yml
@@ -65,6 +65,21 @@ Indices:
             type: keyword
           collection_access:
             type: keyword
+      publications:
+        type: nested
+        properties:
+          publication_title:
+            type: keyword
+          authorship:
+            type: keyword
+          year_of_publication:
+            type: keyword
+          journal_citation:
+            type: keyword
+          digital_object_id:
+            type: keyword
+          pubmed_id:
+            type: integer
 
 
 
@@ -73,6 +88,7 @@ Indices:
       MATCH (s:study)
       optional MATCH (s)<-[:associated_with]-(ic:image_collection)
       optional MATCH (s)<-[:associated_with]-(al:associated_link)
+      optional MATCH (p:publication)-[:of_study]->(s)
       optional MATCH (s)<-[:belongs_to]-(participant)
       optional MATCH (participant)<-[*..2]-(parent)<--(f:file)
       optional MATCH (s)<-[:associated_with]-(df:file)
@@ -99,6 +115,14 @@ Indices:
                     repository_name: ic.repository_name,
                     collection_access: ic.collection_access
                 }) AS image_collection,
+                COLLECT(DISTINCT{
+                  publication_title: p.publication_title,
+                  authorship: p.authorship,
+                  year_of_publication: p.year_of_publication,
+                  journal_citation: p.journal_citation,
+                  digital_object_id: p.digital_object_id,
+                  pubmed_id: CASE WHEN p.pubmed_id IS NULL THEN NULL ELSE toInteger(p.pubmed_id) END
+                }) AS publications,
                 COLLECT(DISTINCT{
                   biomarker_results_available: participant.biomarker_results_available,
                   histology_images_available: participant.histology_images_available,
@@ -203,6 +227,7 @@ Indices:
                 }) AS data_files,
          COLLECT(DISTINCT df.data_file_type) as list_type
       "
+
   # Name of the index to be created, existing index with same name will be deleted
   - index_name: study_specimen
     type: neo4j


### PR DESCRIPTION
The `publicationInfo` GraphQL API was added to the `develop` branch through this PR: https://github.com/CBIIT/crdc-ctdc-backend/pull/164, but it has not been merged into the current release branch.

This PR will sync the changes from `develop` into the `1.4.0` branch to bring in the API needed for the Publication tab on the Study Detail page.

@adamdaventryGov and @erm156, please help resolve the conflicts carefully. The work in `develop` is older, but it includes important publication-related changes Eric worked on that were never brought into the release branch.

Please resolve the conflicts gracefully, test locally, and merge by keeping both the publication changes from `develop` and the recent updates already in `1.4.0`.

Related ticket: [CTDC-1669](https://tracker.nci.nih.gov/browse/CTDC-1669)
