### PR TITLE
Ctdc 2140 

### DIFF
--- a/src/main/resources/graphql/crdc-ctdc-private-es.graphql
+++ b/src/main/resources/graphql/crdc-ctdc-private-es.graphql
@@ -442,6 +442,7 @@ type ParticipantOverview {
   primary_disease_site: String
   stage_of_disease: String
   tumor_grade: String
+  survival_status: String
   age_at_enrollment: Float
   sex: String
   race: String

--- a/src/main/resources/graphql/crdc-ctdc-private-es.graphql
+++ b/src/main/resources/graphql/crdc-ctdc-private-es.graphql
@@ -319,6 +319,7 @@ type StudyFileOverviewInfo {
   primary_diagnosis_disease_group: String
   stage_of_disease: String
   tumor_grade: String
+  survival_status: String
   primary_disease_site: String
   meddra_disease_code: String
   histology: String
@@ -635,6 +636,7 @@ type BiospecimenOverview {
   race: String
   specimen_category: String
   tumor_grade: String
+  survival_status: String
   targeted_therapy: String
   surgical_procedure: String
   age_at_enrollment: String
@@ -667,6 +669,7 @@ type FileOverview {
   data_file_uuid: String
   stage_of_disease: String
   tumor_grade: String
+  survival_status: String
   sex: String
   race: String
   ethnicity: String
@@ -699,6 +702,7 @@ type FileParticipant {
   specimen_id: String
   ctep_disease_term: String
   primary_diagnosis_disease_group: String
+  survival_status: String
   data_file_uuid: String # For Adding Files into Cart
 }
 
@@ -731,6 +735,7 @@ type SearchResult {
   participantCountByAssessmentTimepoint: [GroupCount]
   dataFileCountByDataFileType: [GroupCount]
   dataFileCountByDataFileFormat: [GroupCount]
+  participantCountBySurvivalStatus: [GroupCount]
   studyFileOverviewCountByDataFileType(
     study_short_name: [String] = [],
     study_id: [String] = [],
@@ -759,6 +764,7 @@ type SearchResult {
   filterSpecimenCountBySpecimenType: [GroupCount]
   filterParticipantCountByAssessmentTimepoint: [GroupCount]
   filterParticipantCountByStageOfDisease: [GroupCount]
+  filterParticipantCountBySurvivalStatus: [GroupCount]
   filterDataFileCountByDataFileType: [GroupCount]
   filterDataFileCountByDataFileFormat: [GroupCount]
   filterStudyFileOverviewCountByDataFileType(
@@ -872,6 +878,7 @@ type QueryType {
     study_short_name: [String] = [],
     study_id: [String] = [],
     study_accession: [String] = [],
+    survival_status: [String] = [],
     data_file_uuid: [String] = [],
     data_file_type: [String] = [],
     association: [String] = [],
@@ -882,6 +889,7 @@ type QueryType {
     study_short_name: [String] = [],
     study_id: [String] = [],
     study_accession: [String] = [],
+    survival_status: [String] = [],
     data_file_type: [String] = [],
     data_file_format: [String] = [],
     data_file_uuid: [String] = [],
@@ -912,6 +920,7 @@ type QueryType {
     ctep_disease_term: [String] = []
     primary_diagnosis_disease_group: [String] = []
     stage_of_disease: [String] = []
+    survival_status: [String] = []
     
     tumor_grade: [String] = []
     sex: [String] = []
@@ -946,6 +955,7 @@ type QueryType {
     ctep_disease_term: [String] = []
     primary_diagnosis_disease_group: [String] = []
     stage_of_disease: [String] = []
+    survival_status: [String] = []
     tumor_grade: [String] = []
     sex: [String] = []
     race: [String] = []
@@ -977,6 +987,7 @@ type QueryType {
     ctep_disease_term: [String] = []
     primary_diagnosis_disease_group: [String] = []
     stage_of_disease: [String] = []
+    survival_status: [String] = []
     tumor_grade: [String] = []
     sex: [String] = []
     race: [String] = []
@@ -1011,6 +1022,7 @@ type QueryType {
     ctep_disease_term: [String] = []
     primary_diagnosis_disease_group: [String] = []
     stage_of_disease: [String] = []
+    survival_status: [String] = []
     tumor_grade: [String] = []
     sex: [String] = []
     race: [String] = []
@@ -1046,6 +1058,7 @@ type QueryType {
     ctep_disease_term: [String] = []
     primary_diagnosis_disease_group: [String] = []
     stage_of_disease: [String] = []
+    survival_status: [String] = []
     tumor_grade: [String] = []
     sex: [String] = []
     race: [String] = []
@@ -1072,6 +1085,7 @@ type QueryType {
   searchParticipants(
     ctep_disease_term: [String] = []
     stage_of_disease: [String] = []
+    survival_status: [String] = []
     tumor_grade: [String] = []
     sex: [String] = []
     race: [String] = []
@@ -1095,6 +1109,7 @@ type QueryType {
 
   fileIDsFromList(
     participant_id: [String] = []
+    survival_status: [String] = []
     specimen_id: [String] = []
     data_file_uuid: [String] = []
     data_file_name: [String] = []
@@ -1103,6 +1118,7 @@ type QueryType {
   filesInList(
     data_file_uuid: [String]
     association: [String] = []
+    survival_status: [String] = []
     order_by: String = ""
     sort_direction: String = "ASC"
     first: Int = 10

--- a/src/main/resources/graphql/crdc-ctdc-private-es.graphql
+++ b/src/main/resources/graphql/crdc-ctdc-private-es.graphql
@@ -730,6 +730,7 @@ type SearchResult {
   participantCountByAssessmentTimepoint: [GroupCount]
   dataFileCountByDataFileType: [GroupCount]
   dataFileCountByDataFileFormat: [GroupCount]
+  participantCountByStudyShortName: [GroupCount]
   studyFileOverviewCountByDataFileType(
     study_short_name: [String] = [],
     study_id: [String] = [],
@@ -760,6 +761,7 @@ type SearchResult {
   filterParticipantCountByStageOfDisease: [GroupCount]
   filterDataFileCountByDataFileType: [GroupCount]
   filterDataFileCountByDataFileFormat: [GroupCount]
+  filterParticipantCountByStudyShortName: [GroupCount]
   filterStudyFileOverviewCountByDataFileType(
     study_short_name: [String] = [],
     study_id: [String] = [],

--- a/src/main/resources/graphql/crdc-ctdc-private-es.graphql
+++ b/src/main/resources/graphql/crdc-ctdc-private-es.graphql
@@ -880,10 +880,12 @@ type QueryType {
   studyFileOverview(
     study_short_name: [String] = [],
     study_id: [String] = [],
+    association: [String] = [],
     study_accession: [String] = [],
     data_file_type: [String] = [],
     data_file_format: [String] = [],
     data_file_uuid: [String] = [],
+    ctep_disease_term: [String] = [],
     first: Int,
     offset: Int = 0,
     order_by: String = "data_file_uuid",

--- a/src/main/resources/yaml/es_indices_ctdc.yml
+++ b/src/main/resources/yaml/es_indices_ctdc.yml
@@ -955,6 +955,8 @@ Indices:
         type: keyword
       study_id:
         type: keyword
+      study_accession:
+        type: keyword
       ctep_disease_term:
         type: keyword
       primary_diagnosis_disease_group:
@@ -1097,6 +1099,7 @@ Indices:
       spec.assessment_timepoint AS assessment_timepoint,
       study.study_short_name AS study_short_name,
       toString(study.study_id) AS study_id,
+      study.study_accession AS study_accession,
       [x IN COLLECT(DISTINCT {
       data_file_uuid: df.data_file_uuid,
       data_file_name: df.data_file_name,

--- a/src/main/resources/yaml/es_indices_ctdc.yml
+++ b/src/main/resources/yaml/es_indices_ctdc.yml
@@ -142,6 +142,8 @@ Indices:
     mapping:
       study_short_name:
         type: keyword
+      study_accession:
+        type: keyword
       study_id:
         type: keyword
       list_type:
@@ -200,6 +202,7 @@ Indices:
       optional MATCH (sb:participant)<-[*..2]-(df:file)
       RETURN DISTINCT 
         s.study_short_name as study_short_name,
+        s.study_accession as study_accession,
         toString(s.study_id) AS study_id,
         COLLECT(DISTINCT{
                     data_file_uuid: study_file.data_file_uuid,
@@ -233,6 +236,8 @@ Indices:
     type: neo4j
     mapping:
       study_short_name:
+        type: keyword
+      study_accession:
         type: keyword
       study_id:
         type: keyword
@@ -274,6 +279,7 @@ Indices:
         END AS data_file_type
       RETURN DISTINCT
         s.study_short_name AS study_short_name,
+        s.study_accession AS study_accession,
         s.study_id AS study_id,
         data_file_type AS data_file_type,
         COLLECT(DISTINCT {
@@ -297,6 +303,8 @@ Indices:
     # type mapping for each property of the index
     mapping:
       study_short_name:
+        type: keyword
+      study_accession:
         type: keyword
       study_id:
         type: keyword
@@ -345,6 +353,7 @@ Indices:
       WITH specimen_count, specimen_type, count1, assessment_timepoint, count2, s, sp
       RETURN DISTINCT
         s.study_short_name AS study_short_name,
+        s.study_accession AS study_accession,
         toString(s.study_id) AS study_id,
         COLLECT(DISTINCT{group: assessment_timepoint, count: count2}) AS specimen_timepoints,
         COLLECT(DISTINCT{group: specimen_type, count: count1}) AS specimen_types,
@@ -363,6 +372,8 @@ Indices:
     # type mapping for each property of the index
     mapping:
       study_short_name:
+        type: keyword
+      study_accession:
         type: keyword
       study_id:
         type: keyword
@@ -400,6 +411,7 @@ Indices:
         optional MATCH (s:study)<-[:belongs_to]-(participant)<-[:of_participant]-(sd:diagnosis)
         RETURN DISTINCT
             s.study_short_name AS study_short_name,
+          s.study_accession AS study_accession,
             toString(s.study_id) AS study_id,
             COLLECT(DISTINCT sd.ctep_disease_term) as ctep_disease_terms,
             COLLECT(DISTINCT{
@@ -696,6 +708,8 @@ Indices:
         type: keyword
       study_id:
         type: keyword
+      study_accession:
+        type: keyword
       study_type:
         type: keyword
       study_name:
@@ -868,6 +882,7 @@ Indices:
 
         study.study_short_name                           AS study_short_name,
         study.study_id                                   AS study_id,
+        study.study_accession                            AS study_accession,
         study.study_name                                 AS study_name,
         study.study_type                                 AS study_type,
         study.study_description                          AS study_description,
@@ -1719,6 +1734,8 @@ Indices:
         type: keyword
       study_id:
         type: keyword
+      study_accession:
+        type: keyword
       specimen_id:
         type: keyword
       specimen_record_id:
@@ -1808,6 +1825,7 @@ Indices:
         sub.participant_id                          AS participant_id,
         study.study_short_name                      AS study_short_name,
         toString(study.study_id)                    AS study_id,
+        study.study_accession                       AS study_accession,
 
         diag.ctep_disease_term                      AS ctep_disease_term,
         diag.primary_diagnosis_disease_group        AS primary_diagnosis_disease_group,
@@ -2290,6 +2308,8 @@ Indices:
         type: keyword
       study_id:
         type: keyword
+      study_accession:
+        type: keyword
       unique_node_types:
         type: keyword
       diagnosisNodeData:
@@ -2568,6 +2588,7 @@ Indices:
       RETURN
         study.study_short_name AS study_short_name,
         toString(study.study_id) AS study_id,
+        study.study_accession AS study_accession,
         unique_node_types,
         diagnosisNodeData,
         size(apoc.coll.toSet([d IN diagnosisNodeData | d.diagnosis_record_id])) AS diagnosisNodeCount,
@@ -2591,6 +2612,8 @@ Indices:
       study_short_name:
         type: keyword
       study_id:
+        type: keyword
+      study_accession:
         type: keyword
       targetedTherapyNodeData:
         type: nested
@@ -2745,6 +2768,7 @@ Indices:
       RETURN
         study.study_short_name AS study_short_name,
         toString(study.study_id) AS study_id,
+        study.study_accession AS study_accession,
         targetedTherapyNodeData,
         size(apoc.coll.toSet([t IN targetedTherapyNodeData | t.targeted_therapy_record_id])) AS targetedTherapyNodeCount,
         targetedTherapyParticipantCount,

--- a/src/main/resources/yaml/es_indices_ctdc.yml
+++ b/src/main/resources/yaml/es_indices_ctdc.yml
@@ -1170,13 +1170,33 @@ Indices:
         f,
         associations,
         COLLECT(DISTINCT study_direct)                                                AS direct_studies,
-        apoc.coll.toSet([x IN (COLLECT(sub1) + COLLECT(sub2)) WHERE x IS NOT NULL]) AS subs,
+        apoc.coll.toSet([x IN (COLLECT(sub1) + COLLECT(sub2)) WHERE x IS NOT NULL]) AS file_subs,
         apoc.coll.toSet([x IN COLLECT(spec1) WHERE x IS NOT NULL])                  AS specs
 
-      OPTIONAL MATCH (sPart:participant)-[:belongs_to]->(study:study)
-      WHERE sPart IN subs
+      OPTIONAL MATCH (study_part:participant)-[:belongs_to]->(study_expand:study)
+      WHERE study_expand IN direct_studies
+        AND size(associations) = 1 AND 'study' IN associations
       WITH
-        f, associations, subs, specs, direct_studies,
+        f, associations, direct_studies, file_subs, specs,
+        apoc.coll.toSet(
+          file_subs +
+          [x IN COLLECT(DISTINCT study_part) WHERE x IS NOT NULL]
+        )                                                     AS effective_subs
+
+      OPTIONAL MATCH (expand_spec:specimen)-[:of_participant]->(expand_spec_part:participant)
+      WHERE expand_spec_part IN effective_subs
+        AND size(associations) = 1 AND 'study' IN associations
+      WITH
+        f, associations, effective_subs, direct_studies,
+        apoc.coll.toSet(
+          specs +
+          [x IN COLLECT(DISTINCT expand_spec) WHERE x IS NOT NULL]
+        )                                                     AS specs
+
+      OPTIONAL MATCH (sPart:participant)-[:belongs_to]->(study:study)
+      WHERE sPart IN effective_subs
+      WITH
+        f, associations, effective_subs, specs, direct_studies,
         apoc.coll.toSet(
           COLLECT(DISTINCT study.study_short_name) +
           [s IN direct_studies WHERE s IS NOT NULL | s.study_short_name]
@@ -1191,9 +1211,9 @@ Indices:
         )                                                     AS study_accessions
 
       OPTIONAL MATCH (dPart:participant)<-[:of_participant]-(diag:diagnosis)
-      WHERE dPart IN subs
+      WHERE dPart IN effective_subs
       WITH
-        f, associations, subs, specs, study_short_names, study_ids, study_accessions,
+        f, associations, effective_subs, specs, study_short_names, study_ids, study_accessions,
         COLLECT(DISTINCT diag.ctep_disease_term)              AS ctep_terms,
         COLLECT(DISTINCT diag.primary_diagnosis_disease_group) AS pdg_list,
         COLLECT(DISTINCT diag.stage_of_disease)               AS stage_list,
@@ -1203,9 +1223,9 @@ Indices:
         COLLECT(DISTINCT diag.histology)                      AS histologies
 
       OPTIONAL MATCH (dmPart:participant)<-[:of_participant]-(demo:demographic)
-      WHERE dmPart IN subs
+      WHERE dmPart IN effective_subs
       WITH
-        f, associations, subs, specs, study_short_names, study_ids, study_accessions,
+        f, associations, effective_subs, specs, study_short_names, study_ids, study_accessions,
         ctep_terms, pdg_list, stage_list, tumor_grades, primary_sites, meddra_codes, histologies,
         COLLECT(DISTINCT demo.sex)                            AS sex_list,
         COLLECT(DISTINCT demo.race)                           AS race_list,
@@ -1213,60 +1233,34 @@ Indices:
         COLLECT(DISTINCT demo.age_at_enrollment)              AS ages
 
       OPTIONAL MATCH (exPart:participant)<-[:of_participant]-(exp:exposure)
-      WHERE exPart IN subs
+      WHERE exPart IN effective_subs
       WITH
-        f, associations, subs, specs, study_short_names, study_ids, study_accessions,
+        f, associations, effective_subs, specs, study_short_names, study_ids, study_accessions,
         ctep_terms, pdg_list, stage_list, tumor_grades, primary_sites, meddra_codes, histologies,
         sex_list, race_list, ethnicity_list, ages,
         apoc.coll.toSet(COLLECT(exp.carcinogen_exposure))     AS carcinogen_exposure
 
-       OPTIONAL MATCH (ttPart:participant)<-[:of_participant]-(tt:targeted_therapy)
-      WHERE ttPart IN subs
+      OPTIONAL MATCH (ttPart:participant)<-[:of_participant]-(tt:targeted_therapy)
+      WHERE ttPart IN effective_subs
       WITH
-        f, associations, subs, specs, study_short_names, study_ids, study_accessions,
+        f, associations, effective_subs, specs, study_short_names, study_ids, study_accessions,
         ctep_terms, pdg_list, stage_list, tumor_grades, primary_sites, meddra_codes, histologies,
         sex_list, race_list, ethnicity_list, ages, carcinogen_exposure,
-          apoc.coll.toSet([x IN COLLECT(tt.targeted_therapy) WHERE x IS NOT NULL AND toString(x) <> '']) AS targeted_therapy_raw,
-          apoc.text.join(
-            apoc.coll.sort(apoc.coll.toSet([x IN COLLECT(tt.targeted_therapy) WHERE x IS NOT NULL AND toString(x) <> ''])),
-            '|'
-          )                                                     AS targeted_therapy_string
-
-          OPTIONAL MATCH (study_for_tt:study)<-[:belongs_to]-(study_tt_part:participant)<-[:of_participant]-(study_tt:targeted_therapy)
-          WHERE toString(study_for_tt.study_id) IN study_ids
-          WITH
-            f, associations, subs, specs, study_short_names, study_ids, study_accessions,
-            ctep_terms, pdg_list, stage_list, tumor_grades, primary_sites, meddra_codes, histologies,
-            sex_list, race_list, ethnicity_list, ages, carcinogen_exposure,
-            targeted_therapy_raw, targeted_therapy_string,
-            apoc.coll.toSet([x IN COLLECT(study_tt.targeted_therapy) WHERE x IS NOT NULL AND toString(x) <> '']) AS study_targeted_therapy_raw,
-            apoc.text.join(
-              apoc.coll.sort(apoc.coll.toSet([x IN COLLECT(study_tt.targeted_therapy) WHERE x IS NOT NULL AND toString(x) <> ''])),
-              '|'
-            )                                                     AS study_targeted_therapy_string
-
-        OPTIONAL MATCH (study_for_ctep:study)<-[:belongs_to]-(ctep_part:participant)<-[:of_participant]-(ctep_diag:diagnosis)
-        WHERE toString(study_for_ctep.study_id) IN study_ids
-        WITH
-          f, associations, subs, specs, study_short_names, study_ids, study_accessions,
-          ctep_terms, pdg_list, stage_list, tumor_grades, primary_sites, meddra_codes, histologies,
-          sex_list, race_list, ethnicity_list, ages, carcinogen_exposure,
-            targeted_therapy_raw, targeted_therapy_string,
-            study_targeted_therapy_raw, study_targeted_therapy_string,
-          apoc.coll.toSet([x IN COLLECT(ctep_diag.ctep_disease_term) WHERE x IS NOT NULL]) AS study_ctep_terms
+        apoc.coll.toSet(COLLECT(tt.targeted_therapy))         AS targeted_therapy_raw,
+        apoc.coll.sort([x IN COLLECT(tt.targeted_therapy) WHERE x IS NOT NULL AND x <> ''])
+                                                                AS targeted_therapy_string
 
       RETURN
         'data file' AS type,
-        head([s IN study_short_names WHERE s IS NOT NULL])    AS study_short_name,
-        head([s IN study_ids WHERE s IS NOT NULL])            AS study_id,
-        
-        head([s IN study_accessions WHERE s IS NOT NULL]) AS study_accession,
+        apoc.coll.toSet([s IN study_short_names WHERE s IS NOT NULL])    AS study_short_name,
+        apoc.coll.toSet([s IN study_ids WHERE s IS NOT NULL])            AS study_id,
+        apoc.coll.toSet([s IN study_accessions WHERE s IS NOT NULL])     AS study_accession,
 
-        COALESCE(head([x IN specs WHERE x.anatomical_collection_site IS NOT NULL | apoc.text.capitalizeAll(toLower(x.anatomical_collection_site))]), '') AS anatomical_collection_site,
-        COALESCE(head([x IN specs WHERE x.specimen_type             IS NOT NULL | x.specimen_type            ]), '') AS specimen_type,
-        COALESCE(head([x IN specs WHERE x.tissue_category           IS NOT NULL | x.tissue_category          ]), '') AS tissue_category,
-        COALESCE(head([x IN specs WHERE x.assessment_timepoint      IS NOT NULL | x.assessment_timepoint     ]), '') AS assessment_timepoint,
-        COALESCE(head([x IN specs WHERE x.specimen_record_id        IS NOT NULL | x.specimen_record_id       ]), '') AS specimen_record_id,
+        apoc.coll.toSet([x IN specs WHERE x.anatomical_collection_site IS NOT NULL | apoc.text.capitalizeAll(toLower(x.anatomical_collection_site))]) AS anatomical_collection_site,
+        apoc.coll.toSet([x IN specs WHERE x.specimen_type             IS NOT NULL | x.specimen_type            ]) AS specimen_type,
+        apoc.coll.toSet([x IN specs WHERE x.tissue_category           IS NOT NULL | x.tissue_category          ]) AS tissue_category,
+        apoc.coll.toSet([x IN specs WHERE x.assessment_timepoint      IS NOT NULL | x.assessment_timepoint     ]) AS assessment_timepoint,
+        apoc.coll.toSet([x IN specs WHERE x.specimen_record_id        IS NOT NULL | x.specimen_record_id       ]) AS specimen_record_id,
 
         f.data_file_name                                      AS data_file_name,
         f.data_file_format                                    AS data_file_format,
@@ -1282,36 +1276,24 @@ Indices:
 
         associations                                          AS association,
 
-        head([x IN subs  WHERE x.participant_id IS NOT NULL | x.participant_id]) AS participant_id,
+        apoc.coll.toSet([x IN effective_subs WHERE x.participant_id IS NOT NULL | x.participant_id]) AS participant_id,
 
-        CASE
-          WHEN size(associations) = 1 AND 'study' IN associations
-          THEN study_ctep_terms
-          ELSE head([x IN ctep_terms WHERE x IS NOT NULL])
-        END                                                     AS ctep_disease_term,
-        head([x IN pdg_list     WHERE x IS NOT NULL])          AS primary_diagnosis_disease_group,
-        head([x IN stage_list   WHERE x IS NOT NULL])          AS stage_of_disease,
-        head([x IN tumor_grades WHERE x IS NOT NULL])          AS tumor_grade,
-        head([x IN primary_sites WHERE x IS NOT NULL])         AS primary_disease_site,
-        head([x IN meddra_codes  WHERE x IS NOT NULL])         AS meddra_disease_code,
-        head([x IN histologies   WHERE x IS NOT NULL])         AS histology,
+        apoc.coll.toSet([x IN ctep_terms     WHERE x IS NOT NULL])        AS ctep_disease_term,
+        apoc.coll.toSet([x IN pdg_list       WHERE x IS NOT NULL])        AS primary_diagnosis_disease_group,
+        apoc.coll.toSet([x IN stage_list     WHERE x IS NOT NULL])        AS stage_of_disease,
+        apoc.coll.toSet([x IN tumor_grades   WHERE x IS NOT NULL])        AS tumor_grade,
+        apoc.coll.toSet([x IN primary_sites  WHERE x IS NOT NULL])        AS primary_disease_site,
+        apoc.coll.toSet([x IN meddra_codes   WHERE x IS NOT NULL])        AS meddra_disease_code,
+        apoc.coll.toSet([x IN histologies    WHERE x IS NOT NULL])        AS histology,
 
-        head([x IN sex_list       WHERE x IS NOT NULL])        AS sex,
-        head([x IN race_list      WHERE x IS NOT NULL])        AS race,
-        head([x IN ethnicity_list WHERE x IS NOT NULL])        AS ethnicity,
-        head([x IN ages           WHERE x IS NOT NULL])        AS age_at_enrollment,
+        apoc.coll.toSet([x IN sex_list       WHERE x IS NOT NULL])        AS sex,
+        apoc.coll.toSet([x IN race_list      WHERE x IS NOT NULL])        AS race,
+        apoc.coll.toSet([x IN ethnicity_list WHERE x IS NOT NULL])        AS ethnicity,
+        apoc.coll.toSet([x IN ages           WHERE x IS NOT NULL])        AS age_at_enrollment,
 
         carcinogen_exposure,
-        CASE
-          WHEN size(associations) = 1 AND 'study' IN associations
-          THEN study_targeted_therapy_raw
-          ELSE targeted_therapy_raw
-        END                                                     AS targeted_therapy,
-        CASE
-          WHEN size(associations) = 1 AND 'study' IN associations
-          THEN study_targeted_therapy_string
-          ELSE targeted_therapy_string
-        END                                                     AS targeted_therapy_string,
+        targeted_therapy_raw                                   AS targeted_therapy,
+        targeted_therapy_string                                AS targeted_therapy_string,
 
         [x IN specs | {
           specimen_record_id:          x.specimen_record_id,
@@ -1324,7 +1306,8 @@ Indices:
 
         [{ data_file_uuid: f.data_file_uuid,
           data_file_format: f.data_file_format,
-          data_file_type:   f.data_file_type }]               AS file_info"
+          data_file_type:   f.data_file_type }]               AS file_info
+      "     
   # File Table Data, Add files into cart (For Participant Tab, Biospecimen Tab, and File Tab)
   - index_name: cart_data_files
     type: neo4j

--- a/src/main/resources/yaml/es_indices_ctdc.yml
+++ b/src/main/resources/yaml/es_indices_ctdc.yml
@@ -1156,7 +1156,7 @@ Indices:
         RETURN f.data_file_uuid AS uuid, 'participant' AS association
         UNION
         WITH f
-        MATCH (f)-[:associated_with]-(:specimen)-[:of_participant]->(:participant)
+        MATCH (s)-[:associated_with]-(f)-[:associated_with]-(:specimen)-[:of_participant]->(:participant)
         RETURN f.data_file_uuid AS uuid, 'biospecimen' AS association
       }
       WITH uuid, COLLECT(DISTINCT association) AS associations
@@ -1170,13 +1170,23 @@ Indices:
         f,
         associations,
         COLLECT(DISTINCT study_direct)                                                AS direct_studies,
-        apoc.coll.toSet([x IN (COLLECT(sub1) + COLLECT(sub2)) WHERE x IS NOT NULL]) AS subs,
+        apoc.coll.toSet([x IN (COLLECT(sub1) + COLLECT(sub2)) WHERE x IS NOT NULL]) AS file_subs,
         apoc.coll.toSet([x IN COLLECT(spec1) WHERE x IS NOT NULL])                  AS specs
 
-      OPTIONAL MATCH (sPart:participant)-[:belongs_to]->(study:study)
-      WHERE sPart IN subs
+      OPTIONAL MATCH (study_part:participant)-[:belongs_to]->(study_expand:study)
+      WHERE study_expand IN direct_studies
+        AND size(associations) = 1 AND 'study' IN associations
       WITH
-        f, associations, subs, specs, direct_studies,
+        f, associations, direct_studies, file_subs, specs,
+        apoc.coll.toSet(
+          file_subs +
+          [x IN COLLECT(DISTINCT study_part) WHERE x IS NOT NULL]
+        )                                                     AS effective_subs
+
+      OPTIONAL MATCH (sPart:participant)-[:belongs_to]->(study:study)
+      WHERE sPart IN effective_subs
+      WITH
+        f, associations, effective_subs, specs, direct_studies,
         apoc.coll.toSet(
           COLLECT(DISTINCT study.study_short_name) +
           [s IN direct_studies WHERE s IS NOT NULL | s.study_short_name]
@@ -1191,9 +1201,9 @@ Indices:
         )                                                     AS study_accessions
 
       OPTIONAL MATCH (dPart:participant)<-[:of_participant]-(diag:diagnosis)
-      WHERE dPart IN subs
+      WHERE dPart IN effective_subs
       WITH
-        f, associations, subs, specs, study_short_names, study_ids, study_accessions,
+        f, associations, effective_subs, specs, study_short_names, study_ids, study_accessions,
         COLLECT(DISTINCT diag.ctep_disease_term)              AS ctep_terms,
         COLLECT(DISTINCT diag.primary_diagnosis_disease_group) AS pdg_list,
         COLLECT(DISTINCT diag.stage_of_disease)               AS stage_list,
@@ -1203,9 +1213,9 @@ Indices:
         COLLECT(DISTINCT diag.histology)                      AS histologies
 
       OPTIONAL MATCH (dmPart:participant)<-[:of_participant]-(demo:demographic)
-      WHERE dmPart IN subs
+      WHERE dmPart IN effective_subs
       WITH
-        f, associations, subs, specs, study_short_names, study_ids, study_accessions,
+        f, associations, effective_subs, specs, study_short_names, study_ids, study_accessions,
         ctep_terms, pdg_list, stage_list, tumor_grades, primary_sites, meddra_codes, histologies,
         COLLECT(DISTINCT demo.sex)                            AS sex_list,
         COLLECT(DISTINCT demo.race)                           AS race_list,
@@ -1213,17 +1223,17 @@ Indices:
         COLLECT(DISTINCT demo.age_at_enrollment)              AS ages
 
       OPTIONAL MATCH (exPart:participant)<-[:of_participant]-(exp:exposure)
-      WHERE exPart IN subs
+      WHERE exPart IN effective_subs
       WITH
-        f, associations, subs, specs, study_short_names, study_ids, study_accessions,
+        f, associations, effective_subs, specs, study_short_names, study_ids, study_accessions,
         ctep_terms, pdg_list, stage_list, tumor_grades, primary_sites, meddra_codes, histologies,
         sex_list, race_list, ethnicity_list, ages,
         apoc.coll.toSet(COLLECT(exp.carcinogen_exposure))     AS carcinogen_exposure
 
-       OPTIONAL MATCH (ttPart:participant)<-[:of_participant]-(tt:targeted_therapy)
-      WHERE ttPart IN subs
+      OPTIONAL MATCH (ttPart:participant)<-[:of_participant]-(tt:targeted_therapy)
+      WHERE ttPart IN effective_subs
       WITH
-        f, associations, subs, specs, study_short_names, study_ids, study_accessions,
+        f, associations, effective_subs, specs, study_short_names, study_ids, study_accessions,
         ctep_terms, pdg_list, stage_list, tumor_grades, primary_sites, meddra_codes, histologies,
         sex_list, race_list, ethnicity_list, ages, carcinogen_exposure,
         apoc.coll.toSet(COLLECT(tt.targeted_therapy))         AS targeted_therapy_raw,
@@ -1236,8 +1246,7 @@ Indices:
         'data file' AS type,
         head([s IN study_short_names WHERE s IS NOT NULL])    AS study_short_name,
         head([s IN study_ids WHERE s IS NOT NULL])            AS study_id,
-        
-        head([s IN study_accessions WHERE s IS NOT NULL]) AS study_accession,
+        head([s IN study_accessions WHERE s IS NOT NULL])     AS study_accession,
 
         COALESCE(head([x IN specs WHERE x.anatomical_collection_site IS NOT NULL | apoc.text.capitalizeAll(toLower(x.anatomical_collection_site))]), '') AS anatomical_collection_site,
         COALESCE(head([x IN specs WHERE x.specimen_type             IS NOT NULL | x.specimen_type            ]), '') AS specimen_type,
@@ -1259,9 +1268,9 @@ Indices:
 
         associations                                          AS association,
 
-        head([x IN subs  WHERE x.participant_id IS NOT NULL | x.participant_id]) AS participant_id,
+        head([x IN effective_subs WHERE x.participant_id IS NOT NULL | x.participant_id]) AS participant_id,
 
-        head([x IN ctep_terms   WHERE x IS NOT NULL])          AS ctep_disease_term,
+        ctep_terms                                             AS ctep_disease_term,
         head([x IN pdg_list     WHERE x IS NOT NULL])          AS primary_diagnosis_disease_group,
         head([x IN stage_list   WHERE x IS NOT NULL])          AS stage_of_disease,
         head([x IN tumor_grades WHERE x IS NOT NULL])          AS tumor_grade,
@@ -1291,7 +1300,7 @@ Indices:
           data_file_format: f.data_file_format,
           data_file_type:   f.data_file_type }]               AS file_info
       "
-  # # File Table Data, Add files into cart (For Participant Tab, Biospecimen Tab, and File Tab)
+  # File Table Data, Add files into cart (For Participant Tab, Biospecimen Tab, and File Tab)
   - index_name: cart_data_files
     type: neo4j
     # type mapping for each property of the index
@@ -1652,245 +1661,245 @@ Indices:
       "
   
   # File Table Data for Study-Associated Files
-  # - index_name: study_file_overview
-  #   type: neo4j
-  #   # type mapping for each property of the index
-  #   mapping:
-  #     type:
-  #       type: keyword
-  #     study_short_name:
-  #       type: keyword
-  #     study_id:
-  #       type: keyword
-  #     study_accession:
-  #       type: keyword
-  #     anatomical_collection_site:
-  #       type: keyword
-  #     specimen_type:
-  #       type: keyword
-  #     tissue_category:
-  #       type: keyword
-  #     assessment_timepoint:
-  #       type: keyword
-  #     specimen_record_id:
-  #       type: keyword
-  #     data_file_name:
-  #       type: keyword
-  #     data_file_format:
-  #       type: keyword
-  #     data_file_type:
-  #       type: keyword
-  #     data_file_size:
-  #       type: double
-  #     data_file_uuid:
-  #       type: keyword
-  #     drs_uri:
-  #       type: keyword
-  #     data_file_description:
-  #       type: keyword
-  #     data_file_checksum_value:
-  #       type: keyword
-  #     data_file_checksum_type:
-  #       type: keyword
-  #     data_file_location:
-  #       type: keyword
-  #     data_file_compression_status:
-  #       type: keyword
-  #     association:
-  #       type: keyword
-  #     participant_id:
-  #       type: keyword
-  #     ctep_disease_term:
-  #       type: keyword
-  #     primary_diagnosis_disease_group:
-  #       type: keyword
-  #     stage_of_disease:
-  #       type: keyword
-  #     tumor_grade:
-  #       type: keyword
-  #     primary_disease_site:
-  #       type: keyword
-  #     meddra_disease_code:
-  #       type: keyword
-  #     histology:
-  #       type: keyword
-  #     sex:
-  #       type: keyword
-  #     race:
-  #       type: keyword
-  #     ethnicity:
-  #       type: keyword
-  #     age_at_enrollment:
-  #       type: keyword
-  #     carcinogen_exposure:
-  #       type: keyword
-  #     targeted_therapy:
-  #       type: keyword
-  #     targeted_therapy_string:
-  #       type: keyword
-  #     biospecimen_info:
-  #       type: nested
-  #       properties:
-  #         specimen_record_id:
-  #           type: keyword
-  #         specimen_id:
-  #           type: keyword
-  #         anatomical_collection_site:
-  #           type: keyword
-  #         specimen_type:
-  #           type: keyword
-  #         tissue_category:
-  #           type: keyword
-  #         assessment_timepoint:
-  #           type: keyword
-  #     file_info:
-  #       type: nested
-  #       properties:
-  #         data_file_uuid:
-  #           type: keyword
-  #         data_file_format:
-  #           type: keyword
-  #         data_file_type:
-  #           type: keyword
-  #   cypher_query: "
-  #     MATCH (f:file)
+  - index_name: study_file_overview
+    type: neo4j
+    # type mapping for each property of the index
+    mapping:
+      type:
+        type: keyword
+      study_short_name:
+        type: keyword
+      study_id:
+        type: keyword
+      study_accession:
+        type: keyword
+      anatomical_collection_site:
+        type: keyword
+      specimen_type:
+        type: keyword
+      tissue_category:
+        type: keyword
+      assessment_timepoint:
+        type: keyword
+      specimen_record_id:
+        type: keyword
+      data_file_name:
+        type: keyword
+      data_file_format:
+        type: keyword
+      data_file_type:
+        type: keyword
+      data_file_size:
+        type: double
+      data_file_uuid:
+        type: keyword
+      drs_uri:
+        type: keyword
+      data_file_description:
+        type: keyword
+      data_file_checksum_value:
+        type: keyword
+      data_file_checksum_type:
+        type: keyword
+      data_file_location:
+        type: keyword
+      data_file_compression_status:
+        type: keyword
+      association:
+        type: keyword
+      participant_id:
+        type: keyword
+      ctep_disease_term:
+        type: keyword
+      primary_diagnosis_disease_group:
+        type: keyword
+      stage_of_disease:
+        type: keyword
+      tumor_grade:
+        type: keyword
+      primary_disease_site:
+        type: keyword
+      meddra_disease_code:
+        type: keyword
+      histology:
+        type: keyword
+      sex:
+        type: keyword
+      race:
+        type: keyword
+      ethnicity:
+        type: keyword
+      age_at_enrollment:
+        type: keyword
+      carcinogen_exposure:
+        type: keyword
+      targeted_therapy:
+        type: keyword
+      targeted_therapy_string:
+        type: keyword
+      biospecimen_info:
+        type: nested
+        properties:
+          specimen_record_id:
+            type: keyword
+          specimen_id:
+            type: keyword
+          anatomical_collection_site:
+            type: keyword
+          specimen_type:
+            type: keyword
+          tissue_category:
+            type: keyword
+          assessment_timepoint:
+            type: keyword
+      file_info:
+        type: nested
+        properties:
+          data_file_uuid:
+            type: keyword
+          data_file_format:
+            type: keyword
+          data_file_type:
+            type: keyword
+    cypher_query: "
+      MATCH (f:file)
 
-  #     CALL {
-  #       WITH f
-  #       MATCH (f)-[:associated_with]-(s:study)
-  #       WHERE NOT (f)-[:associated_with]-(:participant)
-  #         AND NOT (f)-[:associated_with]-(:specimen)
-  #       RETURN f.data_file_uuid AS uuid, 'study' AS association
-  #       UNION
-  #       WITH f
-  #       MATCH (f)-[:associated_with]-(:participant)
-  #       WHERE NOT (f)-[:associated_with]-(:specimen)
-  #       RETURN f.data_file_uuid AS uuid, 'participant' AS association
-  #       UNION
-  #       WITH f
-  #       MATCH (f)-[:associated_with]-(:specimen)-[:of_participant]->(:participant)
-  #       RETURN f.data_file_uuid AS uuid, 'biospecimen' AS association
-  #     }
+      CALL {
+        WITH f
+        MATCH (f)-[:associated_with]-(s:study)
+        WHERE NOT (f)-[:associated_with]-(:participant)
+          AND NOT (f)-[:associated_with]-(:specimen)
+        RETURN f.data_file_uuid AS uuid, 'study' AS association
+        UNION
+        WITH f
+        MATCH (f)-[:associated_with]-(:participant)
+        WHERE NOT (f)-[:associated_with]-(:specimen)
+        RETURN f.data_file_uuid AS uuid, 'participant' AS association
+        UNION
+        WITH f
+        MATCH (f)-[:associated_with]-(:specimen)-[:of_participant]->(:participant)
+        RETURN f.data_file_uuid AS uuid, 'biospecimen' AS association
+      }
 
-  #     WITH f, apoc.coll.toSet(COLLECT(DISTINCT association)) AS raw_associations
-  #     WITH f,
-  #       CASE
-  #         WHEN 'study' IN raw_associations
-  #           AND NOT 'participant' IN raw_associations
-  #           AND NOT 'biospecimen' IN raw_associations
-  #         THEN ['study']
-  #         ELSE [a IN raw_associations WHERE a <> 'study']
-  #       END AS associations
+      WITH f, apoc.coll.toSet(COLLECT(DISTINCT association)) AS raw_associations
+      WITH f,
+        CASE
+          WHEN 'study' IN raw_associations
+            AND NOT 'participant' IN raw_associations
+            AND NOT 'biospecimen' IN raw_associations
+          THEN ['study']
+          ELSE [a IN raw_associations WHERE a <> 'study']
+        END AS associations
 
 
-  #     MATCH (study:study)-[:associated_with]-(f)
+      MATCH (study:study)-[:associated_with]-(f)
 
-  #     CALL {
-  #       WITH study
-  #       OPTIONAL MATCH (study)<-[:belongs_to]-(sb:participant)
-  #       WITH sb ORDER BY sb.participant_id
-  #       RETURN head(COLLECT(sb)) AS sb
-  #     }
+      CALL {
+        WITH study
+        OPTIONAL MATCH (study)<-[:belongs_to]-(sb:participant)
+        WITH sb ORDER BY sb.participant_id
+        RETURN head(COLLECT(sb)) AS sb
+      }
 
-  #     CALL {
-  #       WITH sb
-  #       OPTIONAL MATCH (sb)<-[:of_participant]-(spec:specimen)
-  #       WITH spec ORDER BY id(spec) DESC
-  #       RETURN head(COLLECT(spec)) AS spec
-  #     }
+      CALL {
+        WITH sb
+        OPTIONAL MATCH (sb)<-[:of_participant]-(spec:specimen)
+        WITH spec ORDER BY id(spec) DESC
+        RETURN head(COLLECT(spec)) AS spec
+      }
 
-  #     CALL {
-  #       WITH sb
-  #       OPTIONAL MATCH (sb)<-[:of_participant]-(diag:diagnosis)
-  #       WITH diag ORDER BY id(diag) DESC
-  #       RETURN head(COLLECT(diag)) AS diag
-  #     }
+      CALL {
+        WITH sb
+        OPTIONAL MATCH (sb)<-[:of_participant]-(diag:diagnosis)
+        WITH diag ORDER BY id(diag) DESC
+        RETURN head(COLLECT(diag)) AS diag
+      }
 
-  #     CALL {
-  #       WITH sb
-  #       OPTIONAL MATCH (sb)<-[:of_participant]-(demo:demographic)
-  #       WITH demo ORDER BY id(demo) DESC
-  #       RETURN head(COLLECT(demo)) AS demo
-  #     }
+      CALL {
+        WITH sb
+        OPTIONAL MATCH (sb)<-[:of_participant]-(demo:demographic)
+        WITH demo ORDER BY id(demo) DESC
+        RETURN head(COLLECT(demo)) AS demo
+      }
 
-  #     CALL {
-  #       WITH sb
-  #       OPTIONAL MATCH (sb)<-[:of_participant]-(exp:exposure)
-  #       WITH exp ORDER BY id(exp) DESC
-  #       RETURN head(COLLECT(exp)) AS exp
-  #     }
+      CALL {
+        WITH sb
+        OPTIONAL MATCH (sb)<-[:of_participant]-(exp:exposure)
+        WITH exp ORDER BY id(exp) DESC
+        RETURN head(COLLECT(exp)) AS exp
+      }
 
-  #     CALL {
-  #       WITH sb
-  #       OPTIONAL MATCH (sb)<-[:of_participant]-(tt:targeted_therapy)
-  #       WITH [x IN COLLECT(tt.targeted_therapy) WHERE x IS NOT NULL AND x <> ''] AS ts
-  #       WITH apoc.coll.toSet(ts) AS dedup
-  #       RETURN dedup AS targeted_therapy_raw,
-  #              apoc.text.join(apoc.coll.sort(dedup), '|') AS targeted_therapy_string
-  #     }
+      CALL {
+        WITH sb
+        OPTIONAL MATCH (sb)<-[:of_participant]-(tt:targeted_therapy)
+        WITH [x IN COLLECT(tt.targeted_therapy) WHERE x IS NOT NULL AND x <> ''] AS ts
+        WITH apoc.coll.toSet(ts) AS dedup
+        RETURN dedup AS targeted_therapy_raw,
+               apoc.text.join(apoc.coll.sort(dedup), '|') AS targeted_therapy_string
+      }
 
-  #     RETURN DISTINCT
-  #       'data file' AS type,
-  #       study.study_short_name AS study_short_name,
-  #       toString(study.study_id) AS study_id,
-  #       study.study_accession AS study_accession,
-  #       f.data_file_name AS data_file_name,
-  #       f.data_file_format AS data_file_format,
-  #       f.data_file_type AS data_file_type,
-  #       f.data_file_size AS data_file_size,
-  #       f.data_file_uuid AS data_file_uuid,
-  #       'drs://nci-crdc.datacommons.io/' + f.data_file_uuid AS drs_uri,
-  #       f.data_file_description AS data_file_description,
-  #       f.data_file_checksum_value AS data_file_checksum_value,
-  #       f.data_file_checksum_type AS data_file_checksum_type,
-  #       f.data_file_location AS data_file_location,
-  #       f.data_file_compression_status AS data_file_compression_status,
-  #       associations AS association,
-  #       sb.participant_id AS participant_id,
-  #       diag.ctep_disease_term AS ctep_disease_term,
-  #       diag.primary_diagnosis_disease_group AS primary_diagnosis_disease_group,
-  #       diag.stage_of_disease AS stage_of_disease,
-  #       diag.tumor_grade AS tumor_grade,
-  #       diag.primary_disease_site AS primary_disease_site,
-  #       diag.meddra_disease_code AS meddra_disease_code,
-  #       diag.histology AS histology,
-  #       CASE
-  #         WHEN spec IS NULL
-  #           OR spec.anatomical_collection_site IS NULL
-  #           OR trim(spec.anatomical_collection_site) = ''
-  #         THEN ''
-  #         ELSE apoc.text.capitalizeAll(toLower(spec.anatomical_collection_site))
-  #       END AS anatomical_collection_site,
-  #       COALESCE(spec.specimen_type, '') AS specimen_type,
-  #       COALESCE(spec.tissue_category, '') AS tissue_category,
-  #       COALESCE(spec.assessment_timepoint, '') AS assessment_timepoint,
-  #       COALESCE(spec.specimen_record_id, '') AS specimen_record_id,
-  #       demo.sex AS sex,
-  #       demo.race AS race,
-  #       demo.ethnicity AS ethnicity,
-  #       demo.age_at_enrollment AS age_at_enrollment,
-  #       CASE WHEN exp IS NOT NULL AND exp.carcinogen_exposure IS NOT NULL THEN [exp.carcinogen_exposure] ELSE [] END AS carcinogen_exposure,
-  #       targeted_therapy_raw AS targeted_therapy,
-  #       targeted_therapy_string AS targeted_therapy_string,
-  #       CASE WHEN spec IS NOT NULL THEN [
-  #         {
-  #           specimen_record_id: spec.specimen_record_id,
-  #           specimen_id: spec.specimen_id,
-  #           anatomical_collection_site: CASE
-  #             WHEN spec.anatomical_collection_site IS NULL
-  #               OR trim(spec.anatomical_collection_site) = ''
-  #             THEN ''
-  #             ELSE apoc.text.capitalizeAll(toLower(spec.anatomical_collection_site))
-  #           END,
-  #           specimen_type: spec.specimen_type,
-  #           tissue_category: spec.tissue_category,
-  #           assessment_timepoint: spec.assessment_timepoint
-  #         }
-  #       ] ELSE [] END AS biospecimen_info,
-  #       [{ data_file_uuid: f.data_file_uuid,
-  #         data_file_format: f.data_file_format,
-  #         data_file_type: f.data_file_type }] AS file_info
-  #     "
+      RETURN DISTINCT
+        'data file' AS type,
+        study.study_short_name AS study_short_name,
+        toString(study.study_id) AS study_id,
+        study.study_accession AS study_accession,
+        f.data_file_name AS data_file_name,
+        f.data_file_format AS data_file_format,
+        f.data_file_type AS data_file_type,
+        f.data_file_size AS data_file_size,
+        f.data_file_uuid AS data_file_uuid,
+        'drs://nci-crdc.datacommons.io/' + f.data_file_uuid AS drs_uri,
+        f.data_file_description AS data_file_description,
+        f.data_file_checksum_value AS data_file_checksum_value,
+        f.data_file_checksum_type AS data_file_checksum_type,
+        f.data_file_location AS data_file_location,
+        f.data_file_compression_status AS data_file_compression_status,
+        associations AS association,
+        sb.participant_id AS participant_id,
+        diag.ctep_disease_term AS ctep_disease_term,
+        diag.primary_diagnosis_disease_group AS primary_diagnosis_disease_group,
+        diag.stage_of_disease AS stage_of_disease,
+        diag.tumor_grade AS tumor_grade,
+        diag.primary_disease_site AS primary_disease_site,
+        diag.meddra_disease_code AS meddra_disease_code,
+        diag.histology AS histology,
+        CASE
+          WHEN spec IS NULL
+            OR spec.anatomical_collection_site IS NULL
+            OR trim(spec.anatomical_collection_site) = ''
+          THEN ''
+          ELSE apoc.text.capitalizeAll(toLower(spec.anatomical_collection_site))
+        END AS anatomical_collection_site,
+        COALESCE(spec.specimen_type, '') AS specimen_type,
+        COALESCE(spec.tissue_category, '') AS tissue_category,
+        COALESCE(spec.assessment_timepoint, '') AS assessment_timepoint,
+        COALESCE(spec.specimen_record_id, '') AS specimen_record_id,
+        demo.sex AS sex,
+        demo.race AS race,
+        demo.ethnicity AS ethnicity,
+        demo.age_at_enrollment AS age_at_enrollment,
+        CASE WHEN exp IS NOT NULL AND exp.carcinogen_exposure IS NOT NULL THEN [exp.carcinogen_exposure] ELSE [] END AS carcinogen_exposure,
+        targeted_therapy_raw AS targeted_therapy,
+        targeted_therapy_string AS targeted_therapy_string,
+        CASE WHEN spec IS NOT NULL THEN [
+          {
+            specimen_record_id: spec.specimen_record_id,
+            specimen_id: spec.specimen_id,
+            anatomical_collection_site: CASE
+              WHEN spec.anatomical_collection_site IS NULL
+                OR trim(spec.anatomical_collection_site) = ''
+              THEN ''
+              ELSE apoc.text.capitalizeAll(toLower(spec.anatomical_collection_site))
+            END,
+            specimen_type: spec.specimen_type,
+            tissue_category: spec.tissue_category,
+            assessment_timepoint: spec.assessment_timepoint
+          }
+        ] ELSE [] END AS biospecimen_info,
+        [{ data_file_uuid: f.data_file_uuid,
+          data_file_format: f.data_file_format,
+          data_file_type: f.data_file_type }] AS file_info
+      "
             # lists for GS hashmap
   - index_name: gs_list
     type: neo4j

--- a/src/main/resources/yaml/es_indices_ctdc.yml
+++ b/src/main/resources/yaml/es_indices_ctdc.yml
@@ -1278,9 +1278,9 @@ Indices:
         head([x IN meddra_codes  WHERE x IS NOT NULL])         AS meddra_disease_code,
         head([x IN histologies   WHERE x IS NOT NULL])         AS histology,
 
-        head([x IN sex_list       WHERE x IS NOT NULL])        AS sex,
-        head([x IN race_list      WHERE x IS NOT NULL])        AS race,
-        head([x IN ethnicity_list WHERE x IS NOT NULL])        AS ethnicity,
+        apoc.coll.toSet([x IN sex_list       WHERE x IS NOT NULL])        AS sex,
+        apoc.coll.toSet([x IN race_list      WHERE x IS NOT NULL])        AS race,
+        apoc.coll.toSet([x IN ethnicity_list WHERE x IS NOT NULL])        AS ethnicity,
         head([x IN ages           WHERE x IS NOT NULL])        AS age_at_enrollment,
 
         carcinogen_exposure,

--- a/src/main/resources/yaml/es_indices_ctdc.yml
+++ b/src/main/resources/yaml/es_indices_ctdc.yml
@@ -1,7 +1,7 @@
-# Indices settings
+# # Indices settings
 Indices:
-  # First index
-  # Name of the index to be created, existing index with same name will be deleted
+#   # First index
+#   # Name of the index to be created, existing index with same name will be deleted
   - index_name: study
     type: neo4j
     # type mapping for each property of the index
@@ -1285,7 +1285,7 @@ Indices:
       WHERE expand_spec_part IN effective_subs
         AND size(associations) = 1 AND 'study' IN associations
       WITH
-        f, associations, effective_subs, direct_studies,
+        f, associations, effective_subs, file_subs, direct_studies,
         apoc.coll.toSet(
           specs +
           [x IN COLLECT(DISTINCT expand_spec) WHERE x IS NOT NULL]
@@ -1294,7 +1294,7 @@ Indices:
       OPTIONAL MATCH (sPart:participant)-[:belongs_to]->(study:study)
       WHERE sPart IN effective_subs
       WITH
-        f, associations, effective_subs, specs, direct_studies,
+        f, associations, effective_subs, file_subs, specs, direct_studies,
         apoc.coll.toSet(
           COLLECT(DISTINCT study.study_short_name) +
           [s IN direct_studies WHERE s IS NOT NULL | s.study_short_name]
@@ -1311,7 +1311,7 @@ Indices:
       OPTIONAL MATCH (dPart:participant)<-[:of_participant]-(diag:diagnosis)
       WHERE dPart IN effective_subs
       WITH
-        f, associations, effective_subs, specs, study_short_names, study_ids, study_accessions,
+        f, associations, effective_subs, file_subs, specs, study_short_names, study_ids, study_accessions,
         COLLECT(DISTINCT diag.ctep_disease_term)              AS ctep_terms,
         COLLECT(DISTINCT diag.primary_diagnosis_disease_group) AS pdg_list,
         COLLECT(DISTINCT diag.stage_of_disease)               AS stage_list,
@@ -1323,7 +1323,7 @@ Indices:
       OPTIONAL MATCH (dmPart:participant)<-[:of_participant]-(demo:demographic)
       WHERE dmPart IN effective_subs
       WITH
-        f, associations, effective_subs, specs, study_short_names, study_ids, study_accessions,
+        f, associations, effective_subs, file_subs, specs, study_short_names, study_ids, study_accessions,
         ctep_terms, pdg_list, stage_list, tumor_grades, primary_sites, meddra_codes, histologies,
         COLLECT(DISTINCT demo.sex)                            AS sex_list,
         COLLECT(DISTINCT demo.race)                           AS race_list,
@@ -1343,22 +1343,45 @@ Indices:
       WHERE exPart IN effective_subs
       WITH
 
-        f, associations, effective_subs, specs, study_short_names, study_ids, study_accessions, ps_latest,
+        f, associations, effective_subs, file_subs, specs, study_short_names, study_ids, study_accessions, ps_latest,
 
         ctep_terms, pdg_list, stage_list, tumor_grades, primary_sites, meddra_codes, histologies,
         sex_list, race_list, ethnicity_list, ages,
         apoc.coll.toSet(COLLECT(exp.carcinogen_exposure))     AS carcinogen_exposure
 
-      OPTIONAL MATCH (ttPart:participant)<-[:of_participant]-(tt:targeted_therapy)
-      WHERE ttPart IN effective_subs
+      CALL {
+        WITH effective_subs, associations
+        OPTIONAL MATCH (ttPart:participant)<-[:of_participant]-(tt:targeted_therapy)
+        WHERE ttPart IN effective_subs
+        WITH ttPart, COLLECT(tt.targeted_therapy) AS part_tts, associations
+        WITH COLLECT(
+          apoc.text.join(
+            apoc.coll.sort(apoc.coll.toSet([x IN part_tts WHERE x IS NOT NULL AND x <> ''])),
+            '|'
+          )
+        ) AS all_per_part, associations
+        WITH apoc.coll.toSet([x IN all_per_part WHERE x IS NOT NULL AND x <> '']) AS tt_strings,
+          apoc.coll.toSet(
+            reduce(acc = [], s IN all_per_part |
+              acc + [x IN split(s, '|') WHERE x IS NOT NULL AND x <> '']
+            )
+          )                                                    AS tt_raw,
+          associations
+        RETURN
+          CASE WHEN size(associations) = 1 AND 'study' IN associations
+            THEN []
+            ELSE tt_raw
+          END                                                  AS targeted_therapy_raw,
+          tt_strings                                           AS targeted_therapy_string
+      }
+
       WITH
 
-        f, associations, effective_subs, specs, study_short_names, study_ids, study_accessions,ps_latest,
+        f, associations, effective_subs, file_subs, specs, study_short_names, study_ids, study_accessions, ps_latest,
         ctep_terms, pdg_list, stage_list, tumor_grades, primary_sites, meddra_codes, histologies,
         sex_list, race_list, ethnicity_list, ages, carcinogen_exposure,
-        apoc.coll.toSet(COLLECT(tt.targeted_therapy))         AS targeted_therapy_raw,
-        apoc.coll.sort([x IN COLLECT(tt.targeted_therapy) WHERE x IS NOT NULL AND x <> ''])
-                                                                AS targeted_therapy_string
+        targeted_therapy_raw,
+        targeted_therapy_string
 
       RETURN
         'data file' AS type,
@@ -1420,8 +1443,7 @@ Indices:
         [{ data_file_uuid: f.data_file_uuid,
           data_file_format: f.data_file_format,
           data_file_type:   f.data_file_type }]               AS file_info
-      "
-      
+      "   
   # File Table Data, Add files into cart (For Participant Tab, Biospecimen Tab, and File Tab)
   - index_name: cart_data_files
     type: neo4j
@@ -1668,7 +1690,6 @@ Indices:
           data_file_format: f.data_file_format,
           data_file_type:   f.data_file_type }]               AS file_info
       "
-
   #Handles datafiles only related to Biospecimen
   - index_name: biospecimen_data_file
     type: neo4j

--- a/src/main/resources/yaml/es_indices_ctdc.yml
+++ b/src/main/resources/yaml/es_indices_ctdc.yml
@@ -1,4 +1,4 @@
-# # Indices settings
+# Indices settings
 Indices:
 #   # First index
 #   # Name of the index to be created, existing index with same name will be deleted

--- a/src/main/resources/yaml/es_indices_ctdc.yml
+++ b/src/main/resources/yaml/es_indices_ctdc.yml
@@ -943,7 +943,7 @@ Indices:
         ORDER BY coalesce(sb.participant_id, '') ASC
       "
 
-  # # Biospecimen Table Data
+  # Biospecimen Table Data
   - index_name: tab_biospecimens
     type: neo4j
     mapping:

--- a/src/main/resources/yaml/es_indices_ctdc.yml
+++ b/src/main/resources/yaml/es_indices_ctdc.yml
@@ -300,8 +300,6 @@ Indices:
         type: keyword
       study_id:
         type: keyword
-      study_accession:
-        type: keyword
       specimen_types:
         type: nested
         properties:
@@ -348,7 +346,6 @@ Indices:
       RETURN DISTINCT
         s.study_short_name AS study_short_name,
         toString(s.study_id) AS study_id,
-        s.study_accession AS study_accession,
         COLLECT(DISTINCT{group: assessment_timepoint, count: count2}) AS specimen_timepoints,
         COLLECT(DISTINCT{group: specimen_type, count: count1}) AS specimen_types,
         COLLECT(DISTINCT{
@@ -503,8 +500,6 @@ Indices:
         type: keyword
       study_id:
         type: keyword
-      study_accession:
-        type: keyword
       ctep_disease_term:
         type: keyword
       snomed_disease_code:
@@ -627,7 +622,6 @@ Indices:
       sb.participant_id as participant_id,
       COLLECT(DISTINCT study.study_short_name) as study_short_name,
       COLLECT(DISTINCT toString(study.study_id)) as study_id,
-      COLLECT(DISTINCT study.study_accession) as study_accession,
 
       COLLECT(DISTINCT diag.ctep_disease_term) as ctep_disease_term,
       COLLECT(DISTINCT diag.primary_diagnosis_disease_group) as primary_diagnosis_disease_group,
@@ -677,8 +671,6 @@ Indices:
       study_short_name:
         type: keyword
       study_id:
-        type: keyword
-      study_accession:
         type: keyword
       study_type:
         type: keyword
@@ -838,7 +830,6 @@ Indices:
 
         study.study_short_name                           AS study_short_name,
         study.study_id                                   AS study_id,
-        study.study_accession                            AS study_accession,
         study.study_name                                 AS study_name,
         study.study_type                                 AS study_type,
         study.study_description                          AS study_description,
@@ -903,8 +894,6 @@ Indices:
       study_short_name:
         type: keyword
       study_id:
-        type: keyword
-      study_accession:
         type: keyword
       ctep_disease_term:
         type: keyword
@@ -986,6 +975,7 @@ Indices:
         type: keyword
       
     cypher_query: "
+     
       MATCH (spec:specimen)-[:of_participant]->(sub:participant)
       OPTIONAL MATCH (study:study)<-[:belongs_to]-(sub)
       OPTIONAL MATCH (sub)<-[:of_participant]-(demo:demographic)
@@ -1033,7 +1023,6 @@ Indices:
       spec.assessment_timepoint AS assessment_timepoint,
       study.study_short_name AS study_short_name,
       toString(study.study_id) AS study_id,
-      study.study_accession AS study_accession,
       COLLECT(DISTINCT {
       data_file_uuid: df.data_file_uuid,
       data_file_name: df.data_file_name,
@@ -1152,33 +1141,54 @@ Indices:
       study_accession:
         type: keyword
     cypher_query: "
-      CALL {
-        MATCH (sub:participant)<-[*..2]-(parent)<--(f:file)
-        RETURN f.data_file_uuid AS uuid, 'biospecimen' AS association
-        UNION
-        MATCH (sub:participant)<-[:associated_with]-(f:file)
-        RETURN f.data_file_uuid AS uuid, 'participant' AS association
+      MATCH (f:file)-[:associated_with]-(s:study)
 
+      CALL {
+        WITH f
+        MATCH (f)-[:associated_with]-(s:study)
+        WHERE NOT (f)-[:associated_with]-(:participant)
+          AND NOT (f)-[:associated_with]-(:specimen)
+        RETURN f.data_file_uuid AS uuid, 'study' AS association
+        UNION
+        WITH f
+        MATCH (f)-[:associated_with]-(:participant)
+        WHERE NOT (f)-[:associated_with]-(:specimen)
+        RETURN f.data_file_uuid AS uuid, 'participant' AS association
+        UNION
+        WITH f
+        MATCH (f)-[:associated_with]-(:specimen)-[:of_participant]->(:participant)
+        RETURN f.data_file_uuid AS uuid, 'biospecimen' AS association
       }
       WITH uuid, COLLECT(DISTINCT association) AS associations
 
       MATCH (f:file {data_file_uuid: uuid})
 
       OPTIONAL MATCH (f)-[:associated_with]->(spec1:specimen)-[:of_participant]->(sub1:participant)
-       OPTIONAL MATCH (f)-[:associated_with]->(sub2:participant)
+      OPTIONAL MATCH (f)-[:associated_with]->(sub2:participant)
+      OPTIONAL MATCH (f)-[:associated_with]-(study_direct:study)
       WITH
         f,
         associations,
+        COLLECT(DISTINCT study_direct)                                                AS direct_studies,
         apoc.coll.toSet([x IN (COLLECT(sub1) + COLLECT(sub2)) WHERE x IS NOT NULL]) AS subs,
         apoc.coll.toSet([x IN COLLECT(spec1) WHERE x IS NOT NULL])                  AS specs
 
       OPTIONAL MATCH (sPart:participant)-[:belongs_to]->(study:study)
       WHERE sPart IN subs
       WITH
-        f, associations, subs, specs,
-        COLLECT(DISTINCT study.study_short_name)              AS study_short_names,
-        COLLECT(DISTINCT toString(study.study_id))            AS study_ids,
-        COllect(distinct study.study_accession)           AS study_accessions
+        f, associations, subs, specs, direct_studies,
+        apoc.coll.toSet(
+          COLLECT(DISTINCT study.study_short_name) +
+          [s IN direct_studies WHERE s IS NOT NULL | s.study_short_name]
+        )                                                     AS study_short_names,
+        apoc.coll.toSet(
+          COLLECT(DISTINCT toString(study.study_id)) +
+          [s IN direct_studies WHERE s IS NOT NULL | toString(s.study_id)]
+        )                                                     AS study_ids,
+        apoc.coll.toSet(
+          COLLECT(DISTINCT study.study_accession) +
+          [s IN direct_studies WHERE s IS NOT NULL | s.study_accession]
+        )                                                     AS study_accessions
 
       OPTIONAL MATCH (dPart:participant)<-[:of_participant]-(diag:diagnosis)
       WHERE dPart IN subs
@@ -1281,7 +1291,7 @@ Indices:
           data_file_format: f.data_file_format,
           data_file_type:   f.data_file_type }]               AS file_info
       "
-  # File Table Data, Add files into cart (For Participant Tab, Biospecimen Tab, and File Tab)
+  # # File Table Data, Add files into cart (For Participant Tab, Biospecimen Tab, and File Tab)
   - index_name: cart_data_files
     type: neo4j
     # type mapping for each property of the index
@@ -1542,8 +1552,6 @@ Indices:
         type: keyword
       study_id:
         type: keyword
-      study_accession:
-        type: keyword
       specimen_id:
         type: keyword
       specimen_record_id:
@@ -1623,7 +1631,6 @@ Indices:
         sub.participant_id                          AS participant_id,
         study.study_short_name                      AS study_short_name,
         toString(study.study_id)                    AS study_id,
-        study.study_accession                       AS study_accession,
 
         diag.ctep_disease_term                      AS ctep_disease_term,
         diag.primary_diagnosis_disease_group        AS primary_diagnosis_disease_group,
@@ -1645,226 +1652,246 @@ Indices:
       "
   
   # File Table Data for Study-Associated Files
-  - index_name: study_file_overview
-    type: neo4j
-    # type mapping for each property of the index
-    mapping:
-      type:
-        type: keyword
-      study_short_name:
-        type: keyword
-      study_id:
-        type: keyword
-      study_accession:
-        type: keyword
-      anatomical_collection_site:
-        type: keyword
-      specimen_type:
-        type: keyword
-      tissue_category:
-        type: keyword
-      assessment_timepoint:
-        type: keyword
-      specimen_record_id:
-        type: keyword
-      data_file_name:
-        type: keyword
-      data_file_format:
-        type: keyword
-      data_file_type:
-        type: keyword
-      data_file_size:
-        type: double
-      data_file_uuid:
-        type: keyword
-      drs_uri:
-        type: keyword
-      data_file_description:
-        type: keyword
-      data_file_checksum_value:
-        type: keyword
-      data_file_checksum_type:
-        type: keyword
-      data_file_location:
-        type: keyword
-      data_file_compression_status:
-        type: keyword
-      association:
-        type: keyword
-      participant_id:
-        type: keyword
-      ctep_disease_term:
-        type: keyword
-      primary_diagnosis_disease_group:
-        type: keyword
-      stage_of_disease:
-        type: keyword
-      tumor_grade:
-        type: keyword
-      primary_disease_site:
-        type: keyword
-      meddra_disease_code:
-        type: keyword
-      histology:
-        type: keyword
-      sex:
-        type: keyword
-      race:
-        type: keyword
-      ethnicity:
-        type: keyword
-      age_at_enrollment:
-        type: keyword
-      carcinogen_exposure:
-        type: keyword
-      targeted_therapy:
-        type: keyword
-      targeted_therapy_string:
-        type: keyword
-      biospecimen_info:
-        type: nested
-        properties:
-          specimen_record_id:
-            type: keyword
-          specimen_id:
-            type: keyword
-          anatomical_collection_site:
-            type: keyword
-          specimen_type:
-            type: keyword
-          tissue_category:
-            type: keyword
-          assessment_timepoint:
-            type: keyword
-      file_info:
-        type: nested
-        properties:
-          data_file_uuid:
-            type: keyword
-          data_file_format:
-            type: keyword
-          data_file_type:
-            type: keyword
-    cypher_query: "
-      MATCH (f:file)
+  # - index_name: study_file_overview
+  #   type: neo4j
+  #   # type mapping for each property of the index
+  #   mapping:
+  #     type:
+  #       type: keyword
+  #     study_short_name:
+  #       type: keyword
+  #     study_id:
+  #       type: keyword
+  #     study_accession:
+  #       type: keyword
+  #     anatomical_collection_site:
+  #       type: keyword
+  #     specimen_type:
+  #       type: keyword
+  #     tissue_category:
+  #       type: keyword
+  #     assessment_timepoint:
+  #       type: keyword
+  #     specimen_record_id:
+  #       type: keyword
+  #     data_file_name:
+  #       type: keyword
+  #     data_file_format:
+  #       type: keyword
+  #     data_file_type:
+  #       type: keyword
+  #     data_file_size:
+  #       type: double
+  #     data_file_uuid:
+  #       type: keyword
+  #     drs_uri:
+  #       type: keyword
+  #     data_file_description:
+  #       type: keyword
+  #     data_file_checksum_value:
+  #       type: keyword
+  #     data_file_checksum_type:
+  #       type: keyword
+  #     data_file_location:
+  #       type: keyword
+  #     data_file_compression_status:
+  #       type: keyword
+  #     association:
+  #       type: keyword
+  #     participant_id:
+  #       type: keyword
+  #     ctep_disease_term:
+  #       type: keyword
+  #     primary_diagnosis_disease_group:
+  #       type: keyword
+  #     stage_of_disease:
+  #       type: keyword
+  #     tumor_grade:
+  #       type: keyword
+  #     primary_disease_site:
+  #       type: keyword
+  #     meddra_disease_code:
+  #       type: keyword
+  #     histology:
+  #       type: keyword
+  #     sex:
+  #       type: keyword
+  #     race:
+  #       type: keyword
+  #     ethnicity:
+  #       type: keyword
+  #     age_at_enrollment:
+  #       type: keyword
+  #     carcinogen_exposure:
+  #       type: keyword
+  #     targeted_therapy:
+  #       type: keyword
+  #     targeted_therapy_string:
+  #       type: keyword
+  #     biospecimen_info:
+  #       type: nested
+  #       properties:
+  #         specimen_record_id:
+  #           type: keyword
+  #         specimen_id:
+  #           type: keyword
+  #         anatomical_collection_site:
+  #           type: keyword
+  #         specimen_type:
+  #           type: keyword
+  #         tissue_category:
+  #           type: keyword
+  #         assessment_timepoint:
+  #           type: keyword
+  #     file_info:
+  #       type: nested
+  #       properties:
+  #         data_file_uuid:
+  #           type: keyword
+  #         data_file_format:
+  #           type: keyword
+  #         data_file_type:
+  #           type: keyword
+  #   cypher_query: "
+  #     MATCH (f:file)
 
-      CALL {
-        WITH f
-        MATCH (f)-[:associated_with]-(s:study)
-        RETURN f.data_file_uuid AS uuid, 'study' AS association
-        UNION
-        WITH f
-        MATCH (f)-[:associated_with]-(:participant)
-        RETURN f.data_file_uuid AS uuid, 'participant' AS association
-        UNION
-        WITH f
-        MATCH (f)-[:associated_with]-(:specimen)-[:of_participant]->(:participant)
-        RETURN f.data_file_uuid AS uuid, 'biospecimen' AS association
-      }
+  #     CALL {
+  #       WITH f
+  #       MATCH (f)-[:associated_with]-(s:study)
+  #       WHERE NOT (f)-[:associated_with]-(:participant)
+  #         AND NOT (f)-[:associated_with]-(:specimen)
+  #       RETURN f.data_file_uuid AS uuid, 'study' AS association
+  #       UNION
+  #       WITH f
+  #       MATCH (f)-[:associated_with]-(:participant)
+  #       WHERE NOT (f)-[:associated_with]-(:specimen)
+  #       RETURN f.data_file_uuid AS uuid, 'participant' AS association
+  #       UNION
+  #       WITH f
+  #       MATCH (f)-[:associated_with]-(:specimen)-[:of_participant]->(:participant)
+  #       RETURN f.data_file_uuid AS uuid, 'biospecimen' AS association
+  #     }
 
-      WITH f, apoc.coll.toSet(COLLECT(DISTINCT association)) AS associations
-      WHERE 'study' IN associations
-        AND NOT 'participant' IN associations
-        AND NOT 'biospecimen' IN associations
+  #     WITH f, apoc.coll.toSet(COLLECT(DISTINCT association)) AS raw_associations
+  #     WITH f,
+  #       CASE
+  #         WHEN 'study' IN raw_associations
+  #           AND NOT 'participant' IN raw_associations
+  #           AND NOT 'biospecimen' IN raw_associations
+  #         THEN ['study']
+  #         ELSE [a IN raw_associations WHERE a <> 'study']
+  #       END AS associations
 
-      MATCH (study:study)-[:associated_with]-(f)
 
-      CALL {
-        WITH study
-        OPTIONAL MATCH (study)<-[:belongs_to]-(sb:participant)
-        WITH sb ORDER BY sb.participant_id
-        RETURN head(COLLECT(sb)) AS sb
-      }
+  #     MATCH (study:study)-[:associated_with]-(f)
 
-      CALL {
-        WITH sb
-        OPTIONAL MATCH (sb)<-[:of_participant]-(spec:specimen)
-        WITH spec ORDER BY id(spec) DESC
-        RETURN head(COLLECT(spec)) AS spec
-      }
+  #     CALL {
+  #       WITH study
+  #       OPTIONAL MATCH (study)<-[:belongs_to]-(sb:participant)
+  #       WITH sb ORDER BY sb.participant_id
+  #       RETURN head(COLLECT(sb)) AS sb
+  #     }
 
-      CALL {
-        WITH sb
-        OPTIONAL MATCH (sb)<-[:of_participant]-(diag:diagnosis)
-        WITH diag ORDER BY id(diag) DESC
-        RETURN head(COLLECT(diag)) AS diag
-      }
+  #     CALL {
+  #       WITH sb
+  #       OPTIONAL MATCH (sb)<-[:of_participant]-(spec:specimen)
+  #       WITH spec ORDER BY id(spec) DESC
+  #       RETURN head(COLLECT(spec)) AS spec
+  #     }
 
-      CALL {
-        WITH sb
-        OPTIONAL MATCH (sb)<-[:of_participant]-(demo:demographic)
-        WITH demo ORDER BY id(demo) DESC
-        RETURN head(COLLECT(demo)) AS demo
-      }
+  #     CALL {
+  #       WITH sb
+  #       OPTIONAL MATCH (sb)<-[:of_participant]-(diag:diagnosis)
+  #       WITH diag ORDER BY id(diag) DESC
+  #       RETURN head(COLLECT(diag)) AS diag
+  #     }
 
-      CALL {
-        WITH sb
-        OPTIONAL MATCH (sb)<-[:of_participant]-(exp:exposure)
-        WITH exp ORDER BY id(exp) DESC
-        RETURN head(COLLECT(exp)) AS exp
-      }
+  #     CALL {
+  #       WITH sb
+  #       OPTIONAL MATCH (sb)<-[:of_participant]-(demo:demographic)
+  #       WITH demo ORDER BY id(demo) DESC
+  #       RETURN head(COLLECT(demo)) AS demo
+  #     }
 
-      CALL {
-        WITH sb
-        OPTIONAL MATCH (sb)<-[:of_participant]-(tt:targeted_therapy)
-        WITH [x IN COLLECT(tt.targeted_therapy) WHERE x IS NOT NULL AND x <> ''] AS ts
-        WITH apoc.coll.toSet(ts) AS dedup
-        RETURN dedup AS targeted_therapy_raw,
-               apoc.text.join(apoc.coll.sort(dedup), '|') AS targeted_therapy_string
-      }
+  #     CALL {
+  #       WITH sb
+  #       OPTIONAL MATCH (sb)<-[:of_participant]-(exp:exposure)
+  #       WITH exp ORDER BY id(exp) DESC
+  #       RETURN head(COLLECT(exp)) AS exp
+  #     }
 
-      RETURN DISTINCT
-        'data file' AS type,
-        study.study_short_name AS study_short_name,
-        toString(study.study_id) AS study_id,
-        study.study_accession AS study_accession,
-        f.data_file_name AS data_file_name,
-        f.data_file_format AS data_file_format,
-        f.data_file_type AS data_file_type,
-        f.data_file_size AS data_file_size,
-        f.data_file_uuid AS data_file_uuid,
-        'drs://nci-crdc.datacommons.io/' + f.data_file_uuid AS drs_uri,
-        f.data_file_description AS data_file_description,
-        f.data_file_checksum_value AS data_file_checksum_value,
-        f.data_file_checksum_type AS data_file_checksum_type,
-        f.data_file_location AS data_file_location,
-        f.data_file_compression_status AS data_file_compression_status,
-        associations AS association,
-        sb.participant_id AS participant_id,
-        diag.ctep_disease_term AS ctep_disease_term,
-        diag.primary_diagnosis_disease_group AS primary_diagnosis_disease_group,
-        diag.stage_of_disease AS stage_of_disease,
-        diag.tumor_grade AS tumor_grade,
-        diag.primary_disease_site AS primary_disease_site,
-        diag.meddra_disease_code AS meddra_disease_code,
-        diag.histology AS histology,
-        COALESCE(apoc.text.capitalizeAll(toLower(spec.anatomical_collection_site)), '') AS anatomical_collection_site,
-        COALESCE(spec.specimen_type, '') AS specimen_type,
-        COALESCE(spec.tissue_category, '') AS tissue_category,
-        COALESCE(spec.assessment_timepoint, '') AS assessment_timepoint,
-        COALESCE(spec.specimen_record_id, '') AS specimen_record_id,
-        demo.sex AS sex,
-        demo.race AS race,
-        demo.ethnicity AS ethnicity,
-        demo.age_at_enrollment AS age_at_enrollment,
-        CASE WHEN exp IS NOT NULL AND exp.carcinogen_exposure IS NOT NULL THEN [exp.carcinogen_exposure] ELSE [] END AS carcinogen_exposure,
-        targeted_therapy_raw AS targeted_therapy,
-        targeted_therapy_string AS targeted_therapy_string,
-        CASE WHEN spec IS NOT NULL THEN [
-          {
-            specimen_record_id: spec.specimen_record_id,
-            specimen_id: spec.specimen_id,
-            anatomical_collection_site: apoc.text.capitalizeAll(toLower(spec.anatomical_collection_site)),
-            specimen_type: spec.specimen_type,
-            tissue_category: spec.tissue_category,
-            assessment_timepoint: spec.assessment_timepoint
-          }
-        ] ELSE [] END AS biospecimen_info,
-        [{ data_file_uuid: f.data_file_uuid,
-          data_file_format: f.data_file_format,
-          data_file_type: f.data_file_type }] AS file_info
-      "
-            #lists for GS hashmap
+  #     CALL {
+  #       WITH sb
+  #       OPTIONAL MATCH (sb)<-[:of_participant]-(tt:targeted_therapy)
+  #       WITH [x IN COLLECT(tt.targeted_therapy) WHERE x IS NOT NULL AND x <> ''] AS ts
+  #       WITH apoc.coll.toSet(ts) AS dedup
+  #       RETURN dedup AS targeted_therapy_raw,
+  #              apoc.text.join(apoc.coll.sort(dedup), '|') AS targeted_therapy_string
+  #     }
+
+  #     RETURN DISTINCT
+  #       'data file' AS type,
+  #       study.study_short_name AS study_short_name,
+  #       toString(study.study_id) AS study_id,
+  #       study.study_accession AS study_accession,
+  #       f.data_file_name AS data_file_name,
+  #       f.data_file_format AS data_file_format,
+  #       f.data_file_type AS data_file_type,
+  #       f.data_file_size AS data_file_size,
+  #       f.data_file_uuid AS data_file_uuid,
+  #       'drs://nci-crdc.datacommons.io/' + f.data_file_uuid AS drs_uri,
+  #       f.data_file_description AS data_file_description,
+  #       f.data_file_checksum_value AS data_file_checksum_value,
+  #       f.data_file_checksum_type AS data_file_checksum_type,
+  #       f.data_file_location AS data_file_location,
+  #       f.data_file_compression_status AS data_file_compression_status,
+  #       associations AS association,
+  #       sb.participant_id AS participant_id,
+  #       diag.ctep_disease_term AS ctep_disease_term,
+  #       diag.primary_diagnosis_disease_group AS primary_diagnosis_disease_group,
+  #       diag.stage_of_disease AS stage_of_disease,
+  #       diag.tumor_grade AS tumor_grade,
+  #       diag.primary_disease_site AS primary_disease_site,
+  #       diag.meddra_disease_code AS meddra_disease_code,
+  #       diag.histology AS histology,
+  #       CASE
+  #         WHEN spec IS NULL
+  #           OR spec.anatomical_collection_site IS NULL
+  #           OR trim(spec.anatomical_collection_site) = ''
+  #         THEN ''
+  #         ELSE apoc.text.capitalizeAll(toLower(spec.anatomical_collection_site))
+  #       END AS anatomical_collection_site,
+  #       COALESCE(spec.specimen_type, '') AS specimen_type,
+  #       COALESCE(spec.tissue_category, '') AS tissue_category,
+  #       COALESCE(spec.assessment_timepoint, '') AS assessment_timepoint,
+  #       COALESCE(spec.specimen_record_id, '') AS specimen_record_id,
+  #       demo.sex AS sex,
+  #       demo.race AS race,
+  #       demo.ethnicity AS ethnicity,
+  #       demo.age_at_enrollment AS age_at_enrollment,
+  #       CASE WHEN exp IS NOT NULL AND exp.carcinogen_exposure IS NOT NULL THEN [exp.carcinogen_exposure] ELSE [] END AS carcinogen_exposure,
+  #       targeted_therapy_raw AS targeted_therapy,
+  #       targeted_therapy_string AS targeted_therapy_string,
+  #       CASE WHEN spec IS NOT NULL THEN [
+  #         {
+  #           specimen_record_id: spec.specimen_record_id,
+  #           specimen_id: spec.specimen_id,
+  #           anatomical_collection_site: CASE
+  #             WHEN spec.anatomical_collection_site IS NULL
+  #               OR trim(spec.anatomical_collection_site) = ''
+  #             THEN ''
+  #             ELSE apoc.text.capitalizeAll(toLower(spec.anatomical_collection_site))
+  #           END,
+  #           specimen_type: spec.specimen_type,
+  #           tissue_category: spec.tissue_category,
+  #           assessment_timepoint: spec.assessment_timepoint
+  #         }
+  #       ] ELSE [] END AS biospecimen_info,
+  #       [{ data_file_uuid: f.data_file_uuid,
+  #         data_file_format: f.data_file_format,
+  #         data_file_type: f.data_file_type }] AS file_info
+  #     "
+            # lists for GS hashmap
   - index_name: gs_list
     type: neo4j
     # type mapping for each property of the index
@@ -1891,8 +1918,6 @@ Indices:
       study_short_name:
         type: keyword
       study_id:
-        type: keyword
-      study_accession:
         type: keyword
       ctep_disease_term:
         type: keyword
@@ -1981,7 +2006,6 @@ Indices:
       sb.participant_id as participant_id,
       COLLECT(DISTINCT study.study_short_name) as study_short_name,
       COLLECT(DISTINCT toString(study.study_id)) as study_id,
-      COLLECT(DISTINCT study.study_accession) as study_accession,
       COLLECT(DISTINCT diag.ctep_disease_term) as ctep_disease_term,
       COLLECT(DISTINCT diag.primary_diagnosis_disease_group) as primary_diagnosis_disease_group,
       COLLECT(DISTINCT diag.snomed_disease_code) as snomed_disease_code, 
@@ -2379,8 +2403,6 @@ Indices:
         type: keyword
       study_id:
         type: keyword
-      study_accession:
-        type: keyword
       targetedTherapyNodeData:
         type: nested
         properties:
@@ -2534,7 +2556,6 @@ Indices:
       RETURN
         study.study_short_name AS study_short_name,
         toString(study.study_id) AS study_id,
-        study.study_accession AS study_accession,
         targetedTherapyNodeData,
         size(apoc.coll.toSet([t IN targetedTherapyNodeData | t.targeted_therapy_record_id])) AS targetedTherapyNodeCount,
         targetedTherapyParticipantCount,

--- a/src/main/resources/yaml/es_indices_ctdc.yml
+++ b/src/main/resources/yaml/es_indices_ctdc.yml
@@ -1170,23 +1170,13 @@ Indices:
         f,
         associations,
         COLLECT(DISTINCT study_direct)                                                AS direct_studies,
-        apoc.coll.toSet([x IN (COLLECT(sub1) + COLLECT(sub2)) WHERE x IS NOT NULL]) AS file_subs,
+        apoc.coll.toSet([x IN (COLLECT(sub1) + COLLECT(sub2)) WHERE x IS NOT NULL]) AS subs,
         apoc.coll.toSet([x IN COLLECT(spec1) WHERE x IS NOT NULL])                  AS specs
 
-      OPTIONAL MATCH (study_part:participant)-[:belongs_to]->(study_expand:study)
-      WHERE study_expand IN direct_studies
-        AND size(associations) = 1 AND 'study' IN associations
-      WITH
-        f, associations, direct_studies, file_subs, specs,
-        apoc.coll.toSet(
-          file_subs +
-          [x IN COLLECT(DISTINCT study_part) WHERE x IS NOT NULL]
-        )                                                     AS effective_subs
-
       OPTIONAL MATCH (sPart:participant)-[:belongs_to]->(study:study)
-      WHERE sPart IN effective_subs
+      WHERE sPart IN subs
       WITH
-        f, associations, effective_subs, specs, direct_studies,
+        f, associations, subs, specs, direct_studies,
         apoc.coll.toSet(
           COLLECT(DISTINCT study.study_short_name) +
           [s IN direct_studies WHERE s IS NOT NULL | s.study_short_name]
@@ -1201,9 +1191,9 @@ Indices:
         )                                                     AS study_accessions
 
       OPTIONAL MATCH (dPart:participant)<-[:of_participant]-(diag:diagnosis)
-      WHERE dPart IN effective_subs
+      WHERE dPart IN subs
       WITH
-        f, associations, effective_subs, specs, study_short_names, study_ids, study_accessions,
+        f, associations, subs, specs, study_short_names, study_ids, study_accessions,
         COLLECT(DISTINCT diag.ctep_disease_term)              AS ctep_terms,
         COLLECT(DISTINCT diag.primary_diagnosis_disease_group) AS pdg_list,
         COLLECT(DISTINCT diag.stage_of_disease)               AS stage_list,
@@ -1213,9 +1203,9 @@ Indices:
         COLLECT(DISTINCT diag.histology)                      AS histologies
 
       OPTIONAL MATCH (dmPart:participant)<-[:of_participant]-(demo:demographic)
-      WHERE dmPart IN effective_subs
+      WHERE dmPart IN subs
       WITH
-        f, associations, effective_subs, specs, study_short_names, study_ids, study_accessions,
+        f, associations, subs, specs, study_short_names, study_ids, study_accessions,
         ctep_terms, pdg_list, stage_list, tumor_grades, primary_sites, meddra_codes, histologies,
         COLLECT(DISTINCT demo.sex)                            AS sex_list,
         COLLECT(DISTINCT demo.race)                           AS race_list,
@@ -1223,30 +1213,54 @@ Indices:
         COLLECT(DISTINCT demo.age_at_enrollment)              AS ages
 
       OPTIONAL MATCH (exPart:participant)<-[:of_participant]-(exp:exposure)
-      WHERE exPart IN effective_subs
+      WHERE exPart IN subs
       WITH
-        f, associations, effective_subs, specs, study_short_names, study_ids, study_accessions,
+        f, associations, subs, specs, study_short_names, study_ids, study_accessions,
         ctep_terms, pdg_list, stage_list, tumor_grades, primary_sites, meddra_codes, histologies,
         sex_list, race_list, ethnicity_list, ages,
         apoc.coll.toSet(COLLECT(exp.carcinogen_exposure))     AS carcinogen_exposure
 
-      OPTIONAL MATCH (ttPart:participant)<-[:of_participant]-(tt:targeted_therapy)
-      WHERE ttPart IN effective_subs
+       OPTIONAL MATCH (ttPart:participant)<-[:of_participant]-(tt:targeted_therapy)
+      WHERE ttPart IN subs
       WITH
-        f, associations, effective_subs, specs, study_short_names, study_ids, study_accessions,
+        f, associations, subs, specs, study_short_names, study_ids, study_accessions,
         ctep_terms, pdg_list, stage_list, tumor_grades, primary_sites, meddra_codes, histologies,
         sex_list, race_list, ethnicity_list, ages, carcinogen_exposure,
-        apoc.coll.toSet(COLLECT(tt.targeted_therapy))         AS targeted_therapy_raw,
-        apoc.text.join(
-          apoc.coll.sort([x IN COLLECT(tt.targeted_therapy) WHERE x IS NOT NULL AND x <> '']),
-          '|'
-        )                                                     AS targeted_therapy_string
+          apoc.coll.toSet([x IN COLLECT(tt.targeted_therapy) WHERE x IS NOT NULL AND toString(x) <> '']) AS targeted_therapy_raw,
+          apoc.text.join(
+            apoc.coll.sort(apoc.coll.toSet([x IN COLLECT(tt.targeted_therapy) WHERE x IS NOT NULL AND toString(x) <> ''])),
+            '|'
+          )                                                     AS targeted_therapy_string
+
+          OPTIONAL MATCH (study_for_tt:study)<-[:belongs_to]-(study_tt_part:participant)<-[:of_participant]-(study_tt:targeted_therapy)
+          WHERE toString(study_for_tt.study_id) IN study_ids
+          WITH
+            f, associations, subs, specs, study_short_names, study_ids, study_accessions,
+            ctep_terms, pdg_list, stage_list, tumor_grades, primary_sites, meddra_codes, histologies,
+            sex_list, race_list, ethnicity_list, ages, carcinogen_exposure,
+            targeted_therapy_raw, targeted_therapy_string,
+            apoc.coll.toSet([x IN COLLECT(study_tt.targeted_therapy) WHERE x IS NOT NULL AND toString(x) <> '']) AS study_targeted_therapy_raw,
+            apoc.text.join(
+              apoc.coll.sort(apoc.coll.toSet([x IN COLLECT(study_tt.targeted_therapy) WHERE x IS NOT NULL AND toString(x) <> ''])),
+              '|'
+            )                                                     AS study_targeted_therapy_string
+
+        OPTIONAL MATCH (study_for_ctep:study)<-[:belongs_to]-(ctep_part:participant)<-[:of_participant]-(ctep_diag:diagnosis)
+        WHERE toString(study_for_ctep.study_id) IN study_ids
+        WITH
+          f, associations, subs, specs, study_short_names, study_ids, study_accessions,
+          ctep_terms, pdg_list, stage_list, tumor_grades, primary_sites, meddra_codes, histologies,
+          sex_list, race_list, ethnicity_list, ages, carcinogen_exposure,
+            targeted_therapy_raw, targeted_therapy_string,
+            study_targeted_therapy_raw, study_targeted_therapy_string,
+          apoc.coll.toSet([x IN COLLECT(ctep_diag.ctep_disease_term) WHERE x IS NOT NULL]) AS study_ctep_terms
 
       RETURN
         'data file' AS type,
         head([s IN study_short_names WHERE s IS NOT NULL])    AS study_short_name,
         head([s IN study_ids WHERE s IS NOT NULL])            AS study_id,
-        head([s IN study_accessions WHERE s IS NOT NULL])     AS study_accession,
+        
+        head([s IN study_accessions WHERE s IS NOT NULL]) AS study_accession,
 
         COALESCE(head([x IN specs WHERE x.anatomical_collection_site IS NOT NULL | apoc.text.capitalizeAll(toLower(x.anatomical_collection_site))]), '') AS anatomical_collection_site,
         COALESCE(head([x IN specs WHERE x.specimen_type             IS NOT NULL | x.specimen_type            ]), '') AS specimen_type,
@@ -1268,9 +1282,13 @@ Indices:
 
         associations                                          AS association,
 
-        head([x IN effective_subs WHERE x.participant_id IS NOT NULL | x.participant_id]) AS participant_id,
+        head([x IN subs  WHERE x.participant_id IS NOT NULL | x.participant_id]) AS participant_id,
 
-        ctep_terms                                             AS ctep_disease_term,
+        CASE
+          WHEN size(associations) = 1 AND 'study' IN associations
+          THEN study_ctep_terms
+          ELSE head([x IN ctep_terms WHERE x IS NOT NULL])
+        END                                                     AS ctep_disease_term,
         head([x IN pdg_list     WHERE x IS NOT NULL])          AS primary_diagnosis_disease_group,
         head([x IN stage_list   WHERE x IS NOT NULL])          AS stage_of_disease,
         head([x IN tumor_grades WHERE x IS NOT NULL])          AS tumor_grade,
@@ -1278,14 +1296,22 @@ Indices:
         head([x IN meddra_codes  WHERE x IS NOT NULL])         AS meddra_disease_code,
         head([x IN histologies   WHERE x IS NOT NULL])         AS histology,
 
-        apoc.coll.toSet([x IN sex_list       WHERE x IS NOT NULL])        AS sex,
-        apoc.coll.toSet([x IN race_list      WHERE x IS NOT NULL])        AS race,
-        apoc.coll.toSet([x IN ethnicity_list WHERE x IS NOT NULL])        AS ethnicity,
+        head([x IN sex_list       WHERE x IS NOT NULL])        AS sex,
+        head([x IN race_list      WHERE x IS NOT NULL])        AS race,
+        head([x IN ethnicity_list WHERE x IS NOT NULL])        AS ethnicity,
         head([x IN ages           WHERE x IS NOT NULL])        AS age_at_enrollment,
 
         carcinogen_exposure,
-        targeted_therapy_raw                                   AS targeted_therapy,
-        targeted_therapy_string                                AS targeted_therapy_string,
+        CASE
+          WHEN size(associations) = 1 AND 'study' IN associations
+          THEN study_targeted_therapy_raw
+          ELSE targeted_therapy_raw
+        END                                                     AS targeted_therapy,
+        CASE
+          WHEN size(associations) = 1 AND 'study' IN associations
+          THEN study_targeted_therapy_string
+          ELSE targeted_therapy_string
+        END                                                     AS targeted_therapy_string,
 
         [x IN specs | {
           specimen_record_id:          x.specimen_record_id,
@@ -1298,8 +1324,7 @@ Indices:
 
         [{ data_file_uuid: f.data_file_uuid,
           data_file_format: f.data_file_format,
-          data_file_type:   f.data_file_type }]               AS file_info
-      "
+          data_file_type:   f.data_file_type }]               AS file_info"
   # File Table Data, Add files into cart (For Participant Tab, Biospecimen Tab, and File Tab)
   - index_name: cart_data_files
     type: neo4j

--- a/src/main/resources/yaml/es_indices_ctdc.yml
+++ b/src/main/resources/yaml/es_indices_ctdc.yml
@@ -1331,9 +1331,9 @@ Indices:
         COLLECT(DISTINCT demo.age_at_enrollment)              AS ages
 
       CALL {
-        WITH subs
+        WITH effective_subs
         OPTIONAL MATCH (psPart:participant)<-[:of_participant]-(ps:participant_status)
-        WHERE psPart IN subs
+        WHERE psPart IN effective_subs
         WITH ps
         ORDER BY coalesce(datetime(ps.updated), datetime(ps.created)) DESC, id(ps) DESC
         RETURN head(collect(ps)) AS ps_latest

--- a/src/main/resources/yaml/es_indices_ctdc.yml
+++ b/src/main/resources/yaml/es_indices_ctdc.yml
@@ -696,6 +696,8 @@ Indices:
         type: keyword
       tumor_grade:
         type: keyword
+      survival_status:
+        type: keyword
       age_at_enrollment:
         type: integer
       sex:
@@ -832,6 +834,14 @@ Indices:
         RETURN head(collect(dm)) AS demo_latest
       }
 
+      CALL {
+        WITH sb
+        OPTIONAL MATCH (sb)<-[:of_participant]-(ps:participant_status)
+        WITH ps
+        ORDER BY coalesce(datetime(ps.updated), datetime(ps.created)) DESC, id(ps) DESC
+        RETURN head(collect(ps)) AS ps_latest
+      }
+
       RETURN DISTINCT
         'participants'                                  AS type,
         sb.participant_id                               AS participant_id,
@@ -848,6 +858,7 @@ Indices:
         d_latest.primary_diagnosis_disease_group         AS primary_diagnosis_disease_group,
         d_latest.stage_of_disease                        AS stage_of_disease,
         d_latest.tumor_grade                             AS tumor_grade,
+        ps_latest.survival_status                        AS survival_status,
 
         demo_latest.age_at_enrollment                    AS age_at_enrollment,
         demo_latest.sex                                  AS sex,

--- a/src/main/resources/yaml/es_indices_ctdc.yml
+++ b/src/main/resources/yaml/es_indices_ctdc.yml
@@ -1393,7 +1393,7 @@ Indices:
         apoc.coll.toSet([x IN specs WHERE x.specimen_type             IS NOT NULL | x.specimen_type            ]) AS specimen_type,
         apoc.coll.toSet([x IN specs WHERE x.tissue_category           IS NOT NULL | x.tissue_category          ]) AS tissue_category,
         apoc.coll.toSet([x IN specs WHERE x.assessment_timepoint      IS NOT NULL | x.assessment_timepoint     ]) AS assessment_timepoint,
-        apoc.coll.toSet([x IN specs WHERE x.specimen_record_id        IS NOT NULL | x.specimen_record_id       ]) AS specimen_record_id,
+        COALESCE(head([x IN specs WHERE x.specimen_record_id        IS NOT NULL | x.specimen_record_id       ]), '') AS specimen_record_id,
 
         f.data_file_name                                      AS data_file_name,
         f.data_file_format                                    AS data_file_format,
@@ -1410,10 +1410,10 @@ Indices:
 
         associations                                          AS association,
 
-        apoc.coll.toSet([x IN effective_subs WHERE x.participant_id IS NOT NULL | x.participant_id]) AS participant_id,
+        COALESCE(head([x IN effective_subs WHERE x.participant_id IS NOT NULL | x.participant_id]), '') AS participant_id,
 
 
-        apoc.coll.toSet([x IN ctep_terms     WHERE x IS NOT NULL])        AS ctep_disease_term,
+        COALESCE(head([x IN ctep_terms     WHERE x IS NOT NULL]), '')     AS ctep_disease_term,
         apoc.coll.toSet([x IN pdg_list       WHERE x IS NOT NULL])        AS primary_diagnosis_disease_group,
         apoc.coll.toSet([x IN stage_list     WHERE x IS NOT NULL])        AS stage_of_disease,
         apoc.coll.toSet([x IN tumor_grades   WHERE x IS NOT NULL])        AS tumor_grade,

--- a/src/main/resources/yaml/es_indices_ctdc.yml
+++ b/src/main/resources/yaml/es_indices_ctdc.yml
@@ -515,6 +515,8 @@ Indices:
         type: keyword
       diagnosis_id:
         type: keyword
+      survival_status:
+        type: keyword
       sex:
         type: keyword
       race:
@@ -621,6 +623,7 @@ Indices:
       OPTIONAL MATCH (sb)<-[*..2]-(file:file)
       OPTIONAL MATCH (diag:diagnosis)-[:of_participant]->(sb)
       OPTIONAL MATCH (expose:exposure)-[:of_participant]->(sb)
+      OPTIONAL MATCH (ps:participant_status)-[:of_participant]->(sb)
 
       RETURN DISTINCT
       'participant' as type,
@@ -635,6 +638,7 @@ Indices:
       COLLECT(DISTINCT diag.tumor_grade) as tumor_grade,
       COLLECT(DISTINCT diag.stage_of_disease) as stage_of_disease,
       COLLECT(DISTINCT diag.diagnosis_id) as diagnosis_id,
+      COLLECT(DISTINCT ps.survival_status) as survival_status,
       
       sex,
       race,
@@ -979,6 +983,8 @@ Indices:
         type: keyword
       tumor_grade:
         type: keyword
+      survival_status:
+        type: keyword
       sex:
         type: keyword
       race:
@@ -1017,6 +1023,14 @@ Indices:
         best.stage_of_disease                  AS stage_of_disease,
         best.primary_diagnosis_disease_group   AS primary_diagnosis_disease_group,
         best.tumor_grade                       AS tumor_grade
+      }
+
+      CALL {
+        WITH sub
+        OPTIONAL MATCH (sub)<-[:of_participant]-(ps:participant_status)
+        WITH ps
+        ORDER BY coalesce(datetime(ps.updated), datetime(ps.created)) DESC, id(ps) DESC
+        RETURN head(collect(ps)) AS ps_latest
       }
 
       CALL {
@@ -1067,6 +1081,7 @@ Indices:
       }) AS biospecimen_info,
       COLLECT(DISTINCT df.data_file_uuid) AS data_file_uuid,
       tumor_grade,
+      ps_latest.survival_status AS survival_status,
       demo.sex AS sex,
       demo.race AS race,
       demo.ethnicity AS ethnicity,
@@ -1120,6 +1135,8 @@ Indices:
       stage_of_disease:
         type: keyword
       tumor_grade:
+        type: keyword
+      survival_status:
         type: keyword
       sex:
         type: keyword
@@ -1213,10 +1230,19 @@ Indices:
         COLLECT(DISTINCT demo.ethnicity)                      AS ethnicity_list,
         COLLECT(DISTINCT demo.age_at_enrollment)              AS ages
 
+      CALL {
+        WITH subs
+        OPTIONAL MATCH (psPart:participant)<-[:of_participant]-(ps:participant_status)
+        WHERE psPart IN subs
+        WITH ps
+        ORDER BY coalesce(datetime(ps.updated), datetime(ps.created)) DESC, id(ps) DESC
+        RETURN head(collect(ps)) AS ps_latest
+      }
+
       OPTIONAL MATCH (exPart:participant)<-[:of_participant]-(exp:exposure)
       WHERE exPart IN subs
       WITH
-        f, associations, subs, specs, study_short_names, study_ids, study_accessions,
+        f, associations, subs, specs, study_short_names, study_ids, study_accessions, ps_latest,
         ctep_terms, pdg_list, stage_list, tumor_grades, primary_sites, meddra_codes, histologies,
         sex_list, race_list, ethnicity_list, ages,
         apoc.coll.toSet(COLLECT(exp.carcinogen_exposure))     AS carcinogen_exposure
@@ -1224,7 +1250,7 @@ Indices:
        OPTIONAL MATCH (ttPart:participant)<-[:of_participant]-(tt:targeted_therapy)
       WHERE ttPart IN subs
       WITH
-        f, associations, subs, specs, study_short_names, study_ids, study_accessions,
+        f, associations, subs, specs, study_short_names, study_ids, study_accessions, ps_latest,
         ctep_terms, pdg_list, stage_list, tumor_grades, primary_sites, meddra_codes, histologies,
         sex_list, race_list, ethnicity_list, ages, carcinogen_exposure,
         apoc.coll.toSet(COLLECT(tt.targeted_therapy))         AS targeted_therapy_raw,
@@ -1266,6 +1292,7 @@ Indices:
         head([x IN pdg_list     WHERE x IS NOT NULL])          AS primary_diagnosis_disease_group,
         head([x IN stage_list   WHERE x IS NOT NULL])          AS stage_of_disease,
         head([x IN tumor_grades WHERE x IS NOT NULL])          AS tumor_grade,
+        ps_latest.survival_status                              AS survival_status,
         head([x IN primary_sites WHERE x IS NOT NULL])         AS primary_disease_site,
         head([x IN meddra_codes  WHERE x IS NOT NULL])         AS meddra_disease_code,
         head([x IN histologies   WHERE x IS NOT NULL])         AS histology,
@@ -1336,6 +1363,8 @@ Indices:
       stage_of_disease:
         type: keyword
       tumor_grade:
+        type: keyword
+      survival_status:
         type: keyword
       sex:
         type: keyword
@@ -1442,10 +1471,19 @@ Indices:
         COLLECT(DISTINCT demo.ethnicity)                      AS ethnicity_list,
         COLLECT(DISTINCT demo.age_at_enrollment)              AS ages
 
+      CALL {
+        WITH subs
+        OPTIONAL MATCH (psPart:participant)<-[:of_participant]-(ps:participant_status)
+        WHERE psPart IN subs
+        WITH ps
+        ORDER BY coalesce(datetime(ps.updated), datetime(ps.created)) DESC, id(ps) DESC
+        RETURN head(collect(ps)) AS ps_latest
+      }
+
       OPTIONAL MATCH (exPart:participant)<-[:of_participant]-(exp:exposure)
       WHERE exPart IN subs
       WITH
-        f, associations, subs, specs, study_short_names, study_accessions,
+        f, associations, subs, specs, study_short_names, study_accessions, ps_latest,
         ctep_terms, pdg_list, stage_list, tumor_grades, primary_sites, meddra_codes, histologies,
         sex_list, race_list, ethnicity_list, ages,
         apoc.coll.toSet(COLLECT(exp.carcinogen_exposure))     AS carcinogen_exposure
@@ -1453,7 +1491,7 @@ Indices:
        OPTIONAL MATCH (ttPart:participant)<-[:of_participant]-(tt:targeted_therapy)
       WHERE ttPart IN subs
       WITH
-        f, associations, subs, specs, study_short_names,study_accessions,
+        f, associations, subs, specs, study_short_names,study_accessions, ps_latest,
         ctep_terms, pdg_list, stage_list, tumor_grades, primary_sites, meddra_codes, histologies,
         sex_list, race_list, ethnicity_list, ages, carcinogen_exposure,
         apoc.coll.toSet(COLLECT(tt.targeted_therapy))         AS targeted_therapy_raw,
@@ -1500,6 +1538,7 @@ Indices:
         head([x IN pdg_list     WHERE x IS NOT NULL])          AS primary_diagnosis_disease_group,
         head([x IN stage_list   WHERE x IS NOT NULL])          AS stage_of_disease,
         head([x IN tumor_grades WHERE x IS NOT NULL])          AS tumor_grade,
+        ps_latest.survival_status                              AS survival_status,
         head([x IN primary_sites WHERE x IS NOT NULL])         AS primary_disease_site,
         head([x IN meddra_codes  WHERE x IS NOT NULL])         AS meddra_disease_code,
         head([x IN histologies   WHERE x IS NOT NULL])         AS histology,
@@ -1567,6 +1606,8 @@ Indices:
         type: keyword
       tumor_grade:
         type: keyword
+      survival_status:
+        type: keyword
       sex:
         type: keyword
       race:
@@ -1600,9 +1641,17 @@ Indices:
 
       OPTIONAL MATCH (sub)-[:belongs_to]->(study:study)
 
+      CALL {
+        WITH sub
+        OPTIONAL MATCH (sub)<-[:of_participant]-(ps:participant_status)
+        WITH ps
+        ORDER BY coalesce(datetime(ps.updated), datetime(ps.created)) DESC, id(ps) DESC
+        RETURN head(collect(ps)) AS ps_latest
+      }
+
       OPTIONAL MATCH (tt:targeted_therapy)-[:of_participant]->(sub)
       WITH
-        f, sub, spec, study,
+        f, sub, spec, study, ps_latest,
         apoc.coll.toSet([t IN collect(DISTINCT tt.targeted_therapy)
                           WHERE t IS NOT NULL AND t <> '' | t])                AS targeted_therapy,
         apoc.text.join(
@@ -1615,7 +1664,7 @@ Indices:
       OPTIONAL MATCH (sub)<-[:of_participant]-(demo:demographic)
       OPTIONAL MATCH (sub)<-[:of_participant]-(exp:exposure)
       WITH
-        f, sub, spec, study, diag, demo,
+        f, sub, spec, study, diag, demo, ps_latest,
         targeted_therapy, targeted_therapy_string,
         collect(DISTINCT exp.carcinogen_exposure) AS carcinogen_exposure
 
@@ -1640,6 +1689,7 @@ Indices:
         diag.primary_diagnosis_disease_group        AS primary_diagnosis_disease_group,
         diag.stage_of_disease                       AS stage_of_disease,
         diag.tumor_grade                            AS tumor_grade,
+        ps_latest.survival_status                   AS survival_status,
 
         demo.sex                                    AS sex,
         demo.race                                   AS race,
@@ -1711,6 +1761,8 @@ Indices:
       stage_of_disease:
         type: keyword
       tumor_grade:
+        type: keyword
+      survival_status:
         type: keyword
       primary_disease_site:
         type: keyword
@@ -1817,6 +1869,14 @@ Indices:
 
       CALL {
         WITH sb
+        OPTIONAL MATCH (sb)<-[:of_participant]-(ps:participant_status)
+        WITH ps
+        ORDER BY coalesce(datetime(ps.updated), datetime(ps.created)) DESC, id(ps) DESC
+        RETURN head(COLLECT(ps)) AS ps_latest
+      }
+
+      CALL {
+        WITH sb
         OPTIONAL MATCH (sb)<-[:of_participant]-(tt:targeted_therapy)
         WITH [x IN COLLECT(tt.targeted_therapy) WHERE x IS NOT NULL AND x <> ''] AS ts
         WITH apoc.coll.toSet(ts) AS dedup
@@ -1846,6 +1906,7 @@ Indices:
         diag.primary_diagnosis_disease_group AS primary_diagnosis_disease_group,
         diag.stage_of_disease AS stage_of_disease,
         diag.tumor_grade AS tumor_grade,
+        ps_latest.survival_status AS survival_status,
         diag.primary_disease_site AS primary_disease_site,
         diag.meddra_disease_code AS meddra_disease_code,
         diag.histology AS histology,

--- a/src/main/resources/yaml/es_indices_ctdc.yml
+++ b/src/main/resources/yaml/es_indices_ctdc.yml
@@ -1320,9 +1320,9 @@ Indices:
 
       RETURN
         'data file' AS type,
-        apoc.coll.toSet([s IN study_short_names WHERE s IS NOT NULL])    AS study_short_name,
-        apoc.coll.toSet([s IN study_ids WHERE s IS NOT NULL])            AS study_id,
-        apoc.coll.toSet([s IN study_accessions WHERE s IS NOT NULL])     AS study_accession,
+        head([s IN study_short_names WHERE s IS NOT NULL])               AS study_short_name,
+        head([s IN study_ids WHERE s IS NOT NULL])                        AS study_id,
+        head([s IN study_accessions WHERE s IS NOT NULL])                 AS study_accession,
 
         apoc.coll.toSet([x IN specs WHERE x.anatomical_collection_site IS NOT NULL | apoc.text.capitalizeAll(toLower(x.anatomical_collection_site))]) AS anatomical_collection_site,
         apoc.coll.toSet([x IN specs WHERE x.specimen_type             IS NOT NULL | x.specimen_type            ]) AS specimen_type,

--- a/src/main/resources/yaml/es_indices_ctdc.yml
+++ b/src/main/resources/yaml/es_indices_ctdc.yml
@@ -616,6 +616,10 @@ Indices:
       OPTIONAL MATCH (sb)<-[*..2]-(file:file)
       OPTIONAL MATCH (diag:diagnosis)-[:of_participant]->(sb)
       OPTIONAL MATCH (expose:exposure)-[:of_participant]->(sb)
+      OPTIONAL MATCH (study)<-[:associated_with]-(study_zip_file:file)
+      WHERE toLower(coalesce(study_zip_file.data_file_format, '')) = 'zip'
+        AND NOT (study_zip_file)--(:participant)
+        AND NOT (study_zip_file)-[:associated_with]->(:specimen)
 
       RETURN DISTINCT
       'participant' as type,
@@ -643,20 +647,34 @@ Indices:
       COLLECT(DISTINCT spec.assessment_timepoint) AS assessment_timepoint,
       COLLECT(DISTINCT spec.specimen_id) AS specimen_id,
       COLLECT(DISTINCT COALESCE(spec.specimen_type, '')) AS specimen_type,
-      COLLECT(DISTINCT file.data_file_type) AS data_file_type,
-      COLLECT(DISTINCT file.data_file_uuid) AS data_file_uuid,
-      COLLECT(DISTINCT file.data_file_format) AS data_file_format,
+      apoc.coll.toSet(
+        [x IN COLLECT(DISTINCT file.data_file_type) WHERE x IS NOT NULL] +
+        [x IN COLLECT(DISTINCT study_zip_file.data_file_type) WHERE x IS NOT NULL]
+      ) AS data_file_type,
+      apoc.coll.toSet(
+        [x IN COLLECT(DISTINCT file.data_file_uuid) WHERE x IS NOT NULL] +
+        [x IN COLLECT(DISTINCT study_zip_file.data_file_uuid) WHERE x IS NOT NULL]
+      ) AS data_file_uuid,
+      apoc.coll.toSet(
+        [x IN COLLECT(DISTINCT file.data_file_format) WHERE x IS NOT NULL] +
+        [x IN COLLECT(DISTINCT study_zip_file.data_file_format) WHERE x IS NOT NULL]
+      ) AS data_file_format,
       COLLECT(DISTINCT{
         specimen_id: spec.specimen_id,
         anatomical_collection_site: spec.anatomical_collection_site,
         tissue_category: spec.tissue_category,
         assessment_timepoint: spec.assessment_timepoint
       }) AS biospecimen_info,
-      COLLECT(DISTINCT{
+      [x IN COLLECT(DISTINCT{
         data_file_uuid: file.data_file_uuid,
         data_file_format: file.data_file_format,
         data_file_type: file.data_file_type
-      }) AS file_info
+      }) WHERE x.data_file_uuid IS NOT NULL] +
+      [x IN COLLECT(DISTINCT{
+        data_file_uuid: study_zip_file.data_file_uuid,
+        data_file_format: study_zip_file.data_file_format,
+        data_file_type: study_zip_file.data_file_type
+      }) WHERE x.data_file_uuid IS NOT NULL] AS file_info
       " 
 
   # Participant Table Data
@@ -765,7 +783,11 @@ Indices:
       OPTIONAL MATCH (sb)<-[*..2]-(df:file)
       OPTIONAL MATCH (sb)<-[:of_participant]-(spec:specimen)
       OPTIONAL MATCH (sb)<-[:of_participant]-(surgery:surgery)
-      WITH sb, study, spec, df, surgery
+      OPTIONAL MATCH (study)<-[:associated_with]-(study_zip_file:file)
+      WHERE toLower(coalesce(study_zip_file.data_file_format, '')) = 'zip'
+        AND NOT (study_zip_file)--(:participant)
+        AND NOT (study_zip_file)-[:associated_with]->(:specimen)
+      WITH sb, study, spec, df, surgery, study_zip_file
 
       CALL {
         WITH sb
@@ -845,14 +867,23 @@ Indices:
         demo_latest.race                                 AS race,
         demo_latest.ethnicity                            AS ethnicity,
 
-        COLLECT(DISTINCT df.data_file_uuid)              AS data_file_uuid,
+        apoc.coll.toSet(
+          [x IN COLLECT(DISTINCT df.data_file_uuid) WHERE x IS NOT NULL] +
+          [x IN COLLECT(DISTINCT study_zip_file.data_file_uuid) WHERE x IS NOT NULL]
+        )                                                AS data_file_uuid,
         COLLECT(DISTINCT spec.specimen_id)               AS specimen_id,
         anatomical_collection_site,
         COLLECT(DISTINCT spec.specimen_type)             AS specimen_type,
         COLLECT(DISTINCT spec.tissue_category)           AS tissue_category,
         COLLECT(DISTINCT spec.assessment_timepoint)      AS assessment_timepoint,
-        COLLECT(DISTINCT df.data_file_type)              AS data_file_type,
-        COLLECT(DISTINCT df.data_file_format)            AS data_file_format,
+        apoc.coll.toSet(
+          [x IN COLLECT(DISTINCT df.data_file_type) WHERE x IS NOT NULL] +
+          [x IN COLLECT(DISTINCT study_zip_file.data_file_type) WHERE x IS NOT NULL]
+        )                                                AS data_file_type,
+        apoc.coll.toSet(
+          [x IN COLLECT(DISTINCT df.data_file_format) WHERE x IS NOT NULL] +
+          [x IN COLLECT(DISTINCT study_zip_file.data_file_format) WHERE x IS NOT NULL]
+        )                                                AS data_file_format,
 
         targeted_therapy,
         best_response_to_targeted_therapy,
@@ -861,7 +892,7 @@ Indices:
 
         coalesce(e_latest.carcinogen_exposure, '')       AS carcinogen_exposure,
 
-        COLLECT(DISTINCT {
+        [x IN COLLECT(DISTINCT {
           data_file_uuid: df.data_file_uuid,
           data_file_name: df.data_file_name,
           data_file_type: df.data_file_type,
@@ -872,7 +903,19 @@ Indices:
           data_file_checksum_type: df.data_file_checksum_type,
           data_file_compression_status: df.data_file_compression_status,
           data_file_location: df.data_file_location
-        })                                              AS data_files,
+        }) WHERE x.data_file_uuid IS NOT NULL] +
+        [x IN COLLECT(DISTINCT {
+          data_file_uuid: study_zip_file.data_file_uuid,
+          data_file_name: study_zip_file.data_file_name,
+          data_file_type: study_zip_file.data_file_type,
+          data_file_description: study_zip_file.data_file_description,
+          data_file_format: study_zip_file.data_file_format,
+          data_file_size: study_zip_file.data_file_size,
+          data_file_checksum_value: study_zip_file.data_file_checksum_value,
+          data_file_checksum_type: study_zip_file.data_file_checksum_type,
+          data_file_compression_status: study_zip_file.data_file_compression_status,
+          data_file_location: study_zip_file.data_file_location
+        }) WHERE x.data_file_uuid IS NOT NULL]          AS data_files,
         COLLECT(DISTINCT surgery.surgical_procedure)                     AS surgical_procedure,
         COLLECT(DISTINCT surgery.surgical_procedure_anatomical_location) AS surgical_procedure_anatomical_location,
         COLLECT(DISTINCT surgery.surgical_procedure_date)                AS surgical_procedure_date,
@@ -883,7 +926,7 @@ Indices:
         ORDER BY coalesce(sb.participant_id, '') ASC
       "
 
-  # Biospecimen Table Data
+  # # Biospecimen Table Data
   - index_name: tab_biospecimens
     type: neo4j
     mapping:
@@ -981,7 +1024,11 @@ Indices:
       OPTIONAL MATCH (sub)<-[:of_participant]-(demo:demographic)
       OPTIONAL MATCH (sub)<-[:of_participant]-(exp:exposure)
       OPTIONAL MATCH (sub)<-[*..2]-(df:file)
-      WITH sub, spec, study, demo, exp, df,
+      OPTIONAL MATCH (study)<-[:associated_with]-(study_zip_file:file)
+      WHERE toLower(coalesce(study_zip_file.data_file_format, '')) = 'zip'
+        AND NOT (study_zip_file)--(:participant)
+        AND NOT (study_zip_file)-[:associated_with]->(:specimen)
+      WITH sub, spec, study, demo, exp, df, study_zip_file,
           apoc.text.capitalizeAll(toLower(COALESCE(spec.anatomical_collection_site, ''))) AS acs_norm
 
       CALL {
@@ -1023,7 +1070,7 @@ Indices:
       spec.assessment_timepoint AS assessment_timepoint,
       study.study_short_name AS study_short_name,
       toString(study.study_id) AS study_id,
-      COLLECT(DISTINCT {
+      [x IN COLLECT(DISTINCT {
       data_file_uuid: df.data_file_uuid,
       data_file_name: df.data_file_name,
       data_file_type: df.data_file_type,
@@ -1034,7 +1081,19 @@ Indices:
       data_file_checksum_type: df.data_file_checksum_type,
       data_file_compression_status: df.data_file_compression_status,
       data_file_location: df.data_file_location
-      }) AS data_files,
+      }) WHERE x.data_file_uuid IS NOT NULL] +
+      [x IN COLLECT(DISTINCT {
+      data_file_uuid: study_zip_file.data_file_uuid,
+      data_file_name: study_zip_file.data_file_name,
+      data_file_type: study_zip_file.data_file_type,
+      data_file_description: study_zip_file.data_file_description,
+      data_file_format: study_zip_file.data_file_format,
+      data_file_size: study_zip_file.data_file_size,
+      data_file_checksum_value: study_zip_file.data_file_checksum_value,
+      data_file_checksum_type: study_zip_file.data_file_checksum_type,
+      data_file_compression_status: study_zip_file.data_file_compression_status,
+      data_file_location: study_zip_file.data_file_location
+      }) WHERE x.data_file_uuid IS NOT NULL] AS data_files,
       COLLECT(DISTINCT {
       specimen_record_id: spec.specimen_record_id,
       specimen_category: spec.specimen_category,
@@ -1043,7 +1102,10 @@ Indices:
       tissue_category: spec.tissue_category,
       assessment_timepoint: spec.assessment_timepoint
       }) AS biospecimen_info,
-      COLLECT(DISTINCT df.data_file_uuid) AS data_file_uuid,
+      apoc.coll.toSet(
+      [x IN COLLECT(DISTINCT df.data_file_uuid) WHERE x IS NOT NULL] +
+      [x IN COLLECT(DISTINCT study_zip_file.data_file_uuid) WHERE x IS NOT NULL]
+      ) AS data_file_uuid,
       tumor_grade,
       demo.sex AS sex,
       demo.race AS race,
@@ -1051,8 +1113,14 @@ Indices:
       COLLECT(DISTINCT exp.carcinogen_exposure) AS carcinogen_exposure,
       targeted_therapy,
       targeted_therapy_string,
-      COLLECT(DISTINCT df.data_file_type) AS data_file_type,
-      COLLECT(DISTINCT df.data_file_format) AS data_file_format
+      apoc.coll.toSet(
+      [x IN COLLECT(DISTINCT df.data_file_type) WHERE x IS NOT NULL] +
+      [x IN COLLECT(DISTINCT study_zip_file.data_file_type) WHERE x IS NOT NULL]
+      ) AS data_file_type,
+      apoc.coll.toSet(
+      [x IN COLLECT(DISTINCT df.data_file_format) WHERE x IS NOT NULL] +
+      [x IN COLLECT(DISTINCT study_zip_file.data_file_format) WHERE x IS NOT NULL]
+      ) AS data_file_format
       ORDER BY COALESCE(spec.specimen_record_id, '') ASC
       "
   - index_name: tab_data_files
@@ -1267,6 +1335,7 @@ Indices:
         f.data_file_type                                      AS data_file_type,
         f.data_file_size                                      AS data_file_size,
         f.data_file_uuid                                      AS data_file_uuid,
+        f.data_file_uuid                                      AS data_file_uuid_study,
         'drs://nci-crdc.datacommons.io/' + f.data_file_uuid   AS drs_uri,
         f.data_file_description                               AS data_file_description,
         f.data_file_checksum_value                            AS data_file_checksum_value,
@@ -1307,7 +1376,8 @@ Indices:
         [{ data_file_uuid: f.data_file_uuid,
           data_file_format: f.data_file_format,
           data_file_type:   f.data_file_type }]               AS file_info
-      "     
+      "
+      
   # File Table Data, Add files into cart (For Participant Tab, Biospecimen Tab, and File Tab)
   - index_name: cart_data_files
     type: neo4j

--- a/src/main/resources/yaml/facet_search_es.yml
+++ b/src/main/resources/yaml/facet_search_es.yml
@@ -293,6 +293,23 @@ queries:
           selectedField: targeted_therapy_string
         result:
           type: group_count
+      - name: participantCountByStudyShortName
+        index:
+          - widgets_facets_counts
+        filter:
+          type: aggregation
+          selectedField: study_short_name
+        result:
+          type: group_count
+      - name: filterParticipantCountByStudyShortName
+        index:
+          - widgets_facets_counts
+        filter:
+          type: aggregation
+          selectedField: study_short_name
+          ignoreSelectedField: true
+        result:
+          type: group_count
       - name: filterParticipantCountBySingleTargetedTherapyCombinationForFacet
         index:
           - widgets_facets_counts
@@ -510,3 +527,4 @@ queries:
           selectedField: data_file_format
         result:
           type: group_count
+      

--- a/src/main/resources/yaml/facet_search_es.yml
+++ b/src/main/resources/yaml/facet_search_es.yml
@@ -91,7 +91,7 @@ queries:
           method: count_bucket_keys
       - name: numberOfStudyFiles
         index:
-          - study_file_overview
+          - tab_data_files
         filter:
           type: aggregation
           selectedField: data_file_uuid
@@ -478,7 +478,7 @@ queries:
           type: nested_list
       - name: studyFileOverviewCountByDataFileType
         index:
-          - study_file_overview
+          - tab_data_files
         filter:
           type: aggregation
           selectedField: data_file_type
@@ -486,7 +486,7 @@ queries:
           type: group_count
       - name: filterStudyFileOverviewCountByDataFileType
         index:
-          - study_file_overview
+          - tab_data_files
         filter:
           type: aggregation
           ignoreSelectedField: true
@@ -495,7 +495,7 @@ queries:
           type: group_count
       - name: studyFileOverviewCountByDataFileFormat
         index:
-          - study_file_overview
+          - tab_data_files
         filter:
           type: aggregation
           selectedField: data_file_format
@@ -503,7 +503,7 @@ queries:
           type: group_count
       - name: filterStudyFileOverviewCountByDataFileFormat
         index:
-          - study_file_overview
+          - tab_data_files
         filter:
           type: aggregation
           ignoreSelectedField: true

--- a/src/main/resources/yaml/facet_search_es.yml
+++ b/src/main/resources/yaml/facet_search_es.yml
@@ -174,12 +174,29 @@ queries:
           selectedField: stage_of_disease
         result:
           type: group_count
+      - name: participantCountBySurvivalStatus
+        index:
+          - widgets_facets_counts
+        filter:
+          type: aggregation
+          selectedField: survival_status
+        result:
+          type: group_count
       - name: filterParticipantCountByStageOfDisease
         index:
           - widgets_facets_counts
         filter:
           type: aggregation
           selectedField: stage_of_disease
+          ignoreSelectedField: true
+        result:
+          type: group_count
+      - name: filterParticipantCountBySurvivalStatus
+        index:
+          - widgets_facets_counts
+        filter:
+          type: aggregation
+          selectedField: survival_status
           ignoreSelectedField: true
         result:
           type: group_count

--- a/src/main/resources/yaml/single_search_es.yml
+++ b/src/main/resources/yaml/single_search_es.yml
@@ -69,7 +69,7 @@ queries:
       type: object_array
   - name: StudyFileOverviewByStudyShortName
     index:
-      - study_file_overview
+      - tab_data_files
     filter:
       type: default
       caseInsensitive: false
@@ -77,7 +77,7 @@ queries:
       type: object_array
   - name: studyFileOverview
     index:
-      - study_file_overview
+      - tab_data_files
     filter:
       type: pagination
       defaultSortField: data_file_uuid
@@ -85,6 +85,7 @@ queries:
         data_file_uuid: data_file_uuid
         study_short_name: study_short_name
         study_id: study_id
+        association: association
     result:
       type: object_array
   - name: studyZipFileQuery

--- a/src/test/java/gov/nih/nci/bento/ParticipantOverviewConfigurationTest.java
+++ b/src/test/java/gov/nih/nci/bento/ParticipantOverviewConfigurationTest.java
@@ -3,7 +3,7 @@ package gov.nih.nci.bento;
 import graphql.language.ObjectTypeDefinition;
 import graphql.schema.idl.SchemaParser;
 import graphql.schema.idl.TypeDefinitionRegistry;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.yaml.snakeyaml.Yaml;
 
 import java.io.InputStream;
@@ -12,8 +12,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ParticipantOverviewConfigurationTest {
 
@@ -21,18 +22,18 @@ public class ParticipantOverviewConfigurationTest {
     public void participantOverviewSchemaExposesSurvivalStatus() throws Exception {
         String schema;
         try (InputStream inputStream = ClassLoader.getSystemResourceAsStream("graphql/crdc-ctdc-private-es.graphql")) {
-            assertTrue("GraphQL schema should be present", inputStream != null);
+            assertNotNull(inputStream, "GraphQL schema should be present");
             schema = new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
         }
 
         TypeDefinitionRegistry registry = new SchemaParser().parse(schema);
         Optional<ObjectTypeDefinition> participantOverviewType = registry.getType("ParticipantOverview", ObjectTypeDefinition.class);
 
-        assertTrue("ParticipantOverview type should exist", participantOverviewType.isPresent());
+        assertTrue(participantOverviewType.isPresent(), "ParticipantOverview type should exist");
         assertTrue(
-                "ParticipantOverview should expose survival_status",
                 participantOverviewType.get().getFieldDefinitions().stream()
-                        .anyMatch(fieldDefinition -> "survival_status".equals(fieldDefinition.getName()))
+                        .anyMatch(fieldDefinition -> "survival_status".equals(fieldDefinition.getName())),
+                "ParticipantOverview should expose survival_status"
         );
     }
 
@@ -42,24 +43,27 @@ public class ParticipantOverviewConfigurationTest {
         Map<String, Object> yamlConfig;
         Yaml yaml = new Yaml();
         try (InputStream inputStream = ClassLoader.getSystemResourceAsStream("yaml/es_indices_ctdc.yml")) {
-            assertTrue("Index configuration should be present", inputStream != null);
+            assertNotNull(inputStream, "Index configuration should be present");
             yamlConfig = yaml.load(inputStream);
         } catch (Exception e) {
             throw new AssertionError("Unable to load tab_participants configuration", e);
         }
 
-        List<Map<String, Object>> indices = (List<Map<String, Object>>) yamlConfig.get("indices");
+        List<Map<String, Object>> indices = (List<Map<String, Object>>) yamlConfig.get("Indices");
+        assertNotNull(indices, "Indices should be present in the YAML configuration");
         Map<String, Object> tabParticipants = indices.stream()
                 .filter(index -> "tab_participants".equals(index.get("index_name")))
                 .findFirst()
                 .orElseThrow(() -> new AssertionError("tab_participants index is missing"));
 
         Map<String, Object> mapping = (Map<String, Object>) tabParticipants.get("mapping");
-        assertTrue("tab_participants mapping should contain survival_status", mapping.containsKey("survival_status"));
+        assertTrue(mapping.containsKey("survival_status"), "tab_participants mapping should contain survival_status");
         assertEquals("keyword", ((Map<String, Object>) mapping.get("survival_status")).get("type"));
 
         String cypherQuery = (String) tabParticipants.get("cypher_query");
-        assertTrue("tab_participants cypher should pull participant_status nodes", cypherQuery.contains("OPTIONAL MATCH (sb)<-[:of_participant]-(ps:participant_status)"));
-        assertTrue("tab_participants cypher should return survival_status", cypherQuery.contains("survival_status                        AS survival_status"));
+        assertTrue(cypherQuery.contains("OPTIONAL MATCH (sb)<-[:of_participant]-(ps:participant_status)"),
+                "tab_participants cypher should pull participant_status nodes");
+        assertTrue(cypherQuery.contains("ps_latest.survival_status                        AS survival_status"),
+                "tab_participants cypher should return survival_status");
     }
 }

--- a/src/test/java/gov/nih/nci/bento/ParticipantOverviewConfigurationTest.java
+++ b/src/test/java/gov/nih/nci/bento/ParticipantOverviewConfigurationTest.java
@@ -1,0 +1,65 @@
+package gov.nih.nci.bento;
+
+import graphql.language.ObjectTypeDefinition;
+import graphql.schema.idl.SchemaParser;
+import graphql.schema.idl.TypeDefinitionRegistry;
+import org.junit.Test;
+import org.yaml.snakeyaml.Yaml;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class ParticipantOverviewConfigurationTest {
+
+    @Test
+    public void participantOverviewSchemaExposesSurvivalStatus() throws Exception {
+        String schema;
+        try (InputStream inputStream = ClassLoader.getSystemResourceAsStream("graphql/crdc-ctdc-private-es.graphql")) {
+            assertTrue("GraphQL schema should be present", inputStream != null);
+            schema = new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
+        }
+
+        TypeDefinitionRegistry registry = new SchemaParser().parse(schema);
+        Optional<ObjectTypeDefinition> participantOverviewType = registry.getType("ParticipantOverview", ObjectTypeDefinition.class);
+
+        assertTrue("ParticipantOverview type should exist", participantOverviewType.isPresent());
+        assertTrue(
+                "ParticipantOverview should expose survival_status",
+                participantOverviewType.get().getFieldDefinitions().stream()
+                        .anyMatch(fieldDefinition -> "survival_status".equals(fieldDefinition.getName()))
+        );
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void tabParticipantsIndexesSurvivalStatus() {
+        Map<String, Object> yamlConfig;
+        Yaml yaml = new Yaml();
+        try (InputStream inputStream = ClassLoader.getSystemResourceAsStream("yaml/es_indices_ctdc.yml")) {
+            assertTrue("Index configuration should be present", inputStream != null);
+            yamlConfig = yaml.load(inputStream);
+        } catch (Exception e) {
+            throw new AssertionError("Unable to load tab_participants configuration", e);
+        }
+
+        List<Map<String, Object>> indices = (List<Map<String, Object>>) yamlConfig.get("indices");
+        Map<String, Object> tabParticipants = indices.stream()
+                .filter(index -> "tab_participants".equals(index.get("index_name")))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("tab_participants index is missing"));
+
+        Map<String, Object> mapping = (Map<String, Object>) tabParticipants.get("mapping");
+        assertTrue("tab_participants mapping should contain survival_status", mapping.containsKey("survival_status"));
+        assertEquals("keyword", ((Map<String, Object>) mapping.get("survival_status")).get("type"));
+
+        String cypherQuery = (String) tabParticipants.get("cypher_query");
+        assertTrue("tab_participants cypher should pull participant_status nodes", cypherQuery.contains("OPTIONAL MATCH (sb)<-[:of_participant]-(ps:participant_status)"));
+        assertTrue("tab_participants cypher should return survival_status", cypherQuery.contains("survival_status                        AS survival_status"));
+    }
+}

--- a/src/test/java/gov/nih/nci/bento/ParticipantOverviewConfigurationTest.java
+++ b/src/test/java/gov/nih/nci/bento/ParticipantOverviewConfigurationTest.java
@@ -63,7 +63,7 @@ public class ParticipantOverviewConfigurationTest {
         String cypherQuery = (String) tabParticipants.get("cypher_query");
         assertTrue(cypherQuery.contains("OPTIONAL MATCH (sb)<-[:of_participant]-(ps:participant_status)"),
                 "tab_participants cypher should pull participant_status nodes");
-        assertTrue(cypherQuery.contains("ps_latest.survival_status                        AS survival_status"),
+        assertTrue(cypherQuery.contains("ps_latest.survival_status") && cypherQuery.contains("AS survival_status"),
                 "tab_participants cypher should return survival_status");
     }
 }

--- a/src/test/java/gov/nih/nci/bento/SurvivalStatusQueryConfigurationTest.java
+++ b/src/test/java/gov/nih/nci/bento/SurvivalStatusQueryConfigurationTest.java
@@ -36,6 +36,35 @@ public class SurvivalStatusQueryConfigurationTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
+    public void tabBiospecimensPropagatesStudyAccession() {
+        Map<String, Object> yamlConfig;
+        Yaml yaml = new Yaml();
+        try (InputStream inputStream = ClassLoader.getSystemResourceAsStream("yaml/es_indices_ctdc.yml")) {
+            assertNotNull(inputStream, "Index configuration should be present");
+            yamlConfig = yaml.load(inputStream);
+        } catch (Exception e) {
+            throw new AssertionError("Unable to load index configuration", e);
+        }
+
+        List<Map<String, Object>> indices = (List<Map<String, Object>>) yamlConfig.get("Indices");
+        assertNotNull(indices, "Indices should be present in the YAML configuration");
+
+        Map<String, Object> index = indices.stream()
+                .filter(candidate -> "tab_biospecimens".equals(candidate.get("index_name")))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("tab_biospecimens index is missing"));
+
+        Map<String, Object> mapping = (Map<String, Object>) index.get("mapping");
+        assertTrue(mapping.containsKey("study_accession"), "tab_biospecimens mapping should contain study_accession");
+        assertEquals("keyword", ((Map<String, Object>) mapping.get("study_accession")).get("type"));
+
+        String cypherQuery = (String) index.get("cypher_query");
+        assertTrue(cypherQuery.contains("study.study_accession AS study_accession"),
+                "tab_biospecimens cypher should return study_accession");
+    }
+
+    @Test
     public void yamlDefinedQueryArgumentsExposeSurvivalStatus() throws Exception {
         String schema;
         try (InputStream inputStream = ClassLoader.getSystemResourceAsStream("graphql/crdc-ctdc-private-es.graphql")) {

--- a/src/test/java/gov/nih/nci/bento/SurvivalStatusQueryConfigurationTest.java
+++ b/src/test/java/gov/nih/nci/bento/SurvivalStatusQueryConfigurationTest.java
@@ -144,17 +144,17 @@ public class SurvivalStatusQueryConfigurationTest {
         );
     }
 
-            private static void assertQueryArgumentExists(ObjectTypeDefinition queryType, String queryName, String argumentName) {
-            FieldDefinition queryField = queryType.getFieldDefinitions().stream()
+    private static void assertQueryArgumentExists(ObjectTypeDefinition queryType, String queryName, String argumentName) {
+        FieldDefinition queryField = queryType.getFieldDefinitions().stream()
                 .filter(fieldDefinition -> queryName.equals(fieldDefinition.getName()))
                 .findFirst()
                 .orElseThrow(() -> new AssertionError(queryName + " query should exist"));
 
-            assertTrue(
+        assertTrue(
                 queryField.getInputValueDefinitions().stream().anyMatch(argument -> argumentName.equals(argument.getName())),
                 queryName + " should accept " + argumentName
-            );
-            }
+        );
+    }
 
     @SuppressWarnings("unchecked")
     private static void assertIndexPropagatesSurvivalStatus(List<Map<String, Object>> indices, String indexName) {

--- a/src/test/java/gov/nih/nci/bento/SurvivalStatusQueryConfigurationTest.java
+++ b/src/test/java/gov/nih/nci/bento/SurvivalStatusQueryConfigurationTest.java
@@ -12,8 +12,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/src/test/java/gov/nih/nci/bento/SurvivalStatusQueryConfigurationTest.java
+++ b/src/test/java/gov/nih/nci/bento/SurvivalStatusQueryConfigurationTest.java
@@ -1,0 +1,161 @@
+package gov.nih.nci.bento;
+
+import graphql.language.ObjectTypeDefinition;
+import graphql.language.FieldDefinition;
+import graphql.schema.idl.SchemaParser;
+import graphql.schema.idl.TypeDefinitionRegistry;
+import org.junit.jupiter.api.Test;
+import org.yaml.snakeyaml.Yaml;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class SurvivalStatusQueryConfigurationTest {
+
+    @Test
+    public void fileAndBiospecimenSchemaTypesExposeSurvivalStatus() throws Exception {
+        String schema;
+        try (InputStream inputStream = ClassLoader.getSystemResourceAsStream("graphql/crdc-ctdc-private-es.graphql")) {
+            assertNotNull(inputStream, "GraphQL schema should be present");
+            schema = new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
+        }
+
+        TypeDefinitionRegistry registry = new SchemaParser().parse(schema);
+        assertTypeExposesField(registry, "BiospecimenOverview", "survival_status");
+        assertTypeExposesField(registry, "FileOverview", "survival_status");
+        assertTypeExposesField(registry, "FileParticipant", "survival_status");
+        assertTypeExposesField(registry, "StudyFileOverviewInfo", "survival_status");
+    }
+
+    @Test
+    public void yamlDefinedQueryArgumentsExposeSurvivalStatus() throws Exception {
+        String schema;
+        try (InputStream inputStream = ClassLoader.getSystemResourceAsStream("graphql/crdc-ctdc-private-es.graphql")) {
+            assertNotNull(inputStream, "GraphQL schema should be present");
+            schema = new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
+        }
+
+        TypeDefinitionRegistry registry = new SchemaParser().parse(schema);
+        Optional<ObjectTypeDefinition> queryType = registry.getType("QueryType", ObjectTypeDefinition.class);
+        assertTrue(queryType.isPresent(), "QueryType should exist");
+
+        assertQueryArgumentExists(queryType.get(), "StudyFileOverviewByStudyShortName", "survival_status");
+        assertQueryArgumentExists(queryType.get(), "studyFileOverview", "survival_status");
+        assertQueryArgumentExists(queryType.get(), "participantOverview", "survival_status");
+        assertQueryArgumentExists(queryType.get(), "biospecimenOverview", "survival_status");
+        assertQueryArgumentExists(queryType.get(), "fileOverview", "survival_status");
+        assertQueryArgumentExists(queryType.get(), "participant_data_files", "survival_status");
+        assertQueryArgumentExists(queryType.get(), "biospecimen_data_files", "survival_status");
+        assertQueryArgumentExists(queryType.get(), "searchParticipants", "survival_status");
+        assertQueryArgumentExists(queryType.get(), "filesInList", "survival_status");
+        assertQueryArgumentExists(queryType.get(), "fileIDsFromList", "survival_status");
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void yamlIndicesPropagateSurvivalStatus() {
+        Map<String, Object> yamlConfig;
+        Yaml yaml = new Yaml();
+        try (InputStream inputStream = ClassLoader.getSystemResourceAsStream("yaml/es_indices_ctdc.yml")) {
+            assertNotNull(inputStream, "Index configuration should be present");
+            yamlConfig = yaml.load(inputStream);
+        } catch (Exception e) {
+            throw new AssertionError("Unable to load index configuration", e);
+        }
+
+        List<Map<String, Object>> indices = (List<Map<String, Object>>) yamlConfig.get("Indices");
+        assertNotNull(indices, "Indices should be present in the YAML configuration");
+
+        assertIndexPropagatesSurvivalStatus(indices, "tab_biospecimens");
+        assertIndexPropagatesSurvivalStatus(indices, "tab_data_files");
+        assertIndexPropagatesSurvivalStatus(indices, "cart_data_files");
+        assertIndexPropagatesSurvivalStatus(indices, "biospecimen_data_file");
+        assertIndexPropagatesSurvivalStatus(indices, "study_file_overview");
+        assertIndexPropagatesSurvivalStatus(indices, "widgets_facets_counts");
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void facetSearchConfigurationExposesSurvivalStatusFacet() {
+        Map<String, Object> yamlConfig;
+        Yaml yaml = new Yaml();
+        try (InputStream inputStream = ClassLoader.getSystemResourceAsStream("yaml/facet_search_es.yml")) {
+            assertNotNull(inputStream, "Facet configuration should be present");
+            yamlConfig = yaml.load(inputStream);
+        } catch (Exception e) {
+            throw new AssertionError("Unable to load facet configuration", e);
+        }
+
+        List<Map<String, Object>> queries = (List<Map<String, Object>>) yamlConfig.get("queries");
+        assertNotNull(queries, "Queries should be present in the facet YAML configuration");
+        Map<String, Object> searchParticipants = queries.stream()
+                .filter(query -> "searchParticipants".equals(query.get("name")))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("searchParticipants query is missing"));
+
+        List<Map<String, Object>> returnFields = (List<Map<String, Object>>) searchParticipants.get("returnFields");
+        assertNotNull(returnFields, "searchParticipants return fields should be present");
+
+        assertFacetFieldExists(returnFields, "participantCountBySurvivalStatus");
+        assertFacetFieldExists(returnFields, "filterParticipantCountBySurvivalStatus");
+    }
+
+    private static void assertTypeExposesField(TypeDefinitionRegistry registry, String typeName, String fieldName) {
+        Optional<ObjectTypeDefinition> type = registry.getType(typeName, ObjectTypeDefinition.class);
+        assertTrue(type.isPresent(), typeName + " type should exist");
+        assertTrue(
+                type.get().getFieldDefinitions().stream().anyMatch(fieldDefinition -> fieldName.equals(fieldDefinition.getName())),
+                typeName + " should expose " + fieldName
+        );
+    }
+
+            private static void assertQueryArgumentExists(ObjectTypeDefinition queryType, String queryName, String argumentName) {
+            FieldDefinition queryField = queryType.getFieldDefinitions().stream()
+                .filter(fieldDefinition -> queryName.equals(fieldDefinition.getName()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError(queryName + " query should exist"));
+
+            assertTrue(
+                queryField.getInputValueDefinitions().stream().anyMatch(argument -> argumentName.equals(argument.getName())),
+                queryName + " should accept " + argumentName
+            );
+            }
+
+    @SuppressWarnings("unchecked")
+    private static void assertIndexPropagatesSurvivalStatus(List<Map<String, Object>> indices, String indexName) {
+        Map<String, Object> index = indices.stream()
+                .filter(candidate -> indexName.equals(candidate.get("index_name")))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError(indexName + " index is missing"));
+
+        Map<String, Object> mapping = (Map<String, Object>) index.get("mapping");
+        assertTrue(mapping.containsKey("survival_status"), indexName + " mapping should contain survival_status");
+        assertEquals("keyword", ((Map<String, Object>) mapping.get("survival_status")).get("type"));
+
+        String cypherQuery = (String) index.get("cypher_query");
+        assertTrue(cypherQuery.contains("participant_status"), indexName + " cypher should pull participant_status nodes");
+        assertTrue(cypherQuery.contains("survival_status"), indexName + " cypher should return survival_status");
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void assertFacetFieldExists(List<Map<String, Object>> returnFields, String fieldName) {
+        Map<String, Object> field = returnFields.stream()
+                .filter(candidate -> fieldName.equals(candidate.get("name")))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError(fieldName + " facet field should exist"));
+
+        Map<String, Object> filter = (Map<String, Object>) field.get("filter");
+        assertEquals("survival_status", filter.get("selectedField"));
+
+        List<String> index = (List<String>) field.get("index");
+        assertEquals(List.of("widgets_facets_counts"), index);
+    }
+}

--- a/src/test/java/gov/nih/nci/bento/TabDataFilesCypherRegressionTest.java
+++ b/src/test/java/gov/nih/nci/bento/TabDataFilesCypherRegressionTest.java
@@ -1,0 +1,38 @@
+package gov.nih.nci.bento;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TabDataFilesCypherRegressionTest {
+
+    private static final String YAML_PATH = "src/main/resources/yaml/es_indices_ctdc.yml";
+
+    @Test
+    public void tabDataFilesCypher_shouldContainStudyOnlyFallbackLogic() throws IOException {
+        String yaml = Files.readString(Paths.get(YAML_PATH), StandardCharsets.UTF_8);
+
+        // Locate just the tab_data_files index block so assertions stay scoped to this ticket behavior.
+        String blockStart = "- index_name: tab_data_files";
+        String blockEnd = "- index_name: cart_data_files";
+        int start = yaml.indexOf(blockStart);
+        int end = yaml.indexOf(blockEnd);
+
+        assertTrue(start >= 0, "tab_data_files block must exist");
+        assertTrue(end > start, "cart_data_files block must exist after tab_data_files");
+
+        String tabDataFilesBlock = yaml.substring(start, end);
+
+        assertTrue(tabDataFilesBlock.contains("OPTIONAL MATCH (f)-[:associated_with]-(study_direct:study)"));
+        assertTrue(tabDataFilesBlock.contains("OPTIONAL MATCH (study_part:participant)-[:belongs_to]->(study_expand:study)"));
+        assertTrue(tabDataFilesBlock.contains("AND size(associations) = 1 AND 'study' IN associations"));
+        assertTrue(tabDataFilesBlock.contains("AS effective_subs"));
+        assertTrue(tabDataFilesBlock.contains("WHERE dPart IN effective_subs"));
+        assertTrue(tabDataFilesBlock.contains("head([x IN effective_subs WHERE x.participant_id IS NOT NULL | x.participant_id]) AS participant_id"));
+    }
+}

--- a/src/test/java/gov/nih/nci/bento/TabDataFilesCypherRegressionTest.java
+++ b/src/test/java/gov/nih/nci/bento/TabDataFilesCypherRegressionTest.java
@@ -33,6 +33,10 @@ public class TabDataFilesCypherRegressionTest {
         assertTrue(tabDataFilesBlock.contains("AND size(associations) = 1 AND 'study' IN associations"));
         assertTrue(tabDataFilesBlock.contains("AS effective_subs"));
         assertTrue(tabDataFilesBlock.contains("WHERE dPart IN effective_subs"));
-        assertTrue(tabDataFilesBlock.contains("head([x IN effective_subs WHERE x.participant_id IS NOT NULL | x.participant_id]) AS participant_id"));
+        assertTrue(tabDataFilesBlock.contains("apoc.coll.toSet([x IN effective_subs WHERE x.participant_id IS NOT NULL | x.participant_id]) AS participant_id"));
+
+        // target_therapy_string should be a single joined string, not an array mixing raw terms and joined terms.
+        assertTrue(tabDataFilesBlock.contains("joined_str                                               AS targeted_therapy_string"));
+        assertTrue(!tabDataFilesBlock.contains("tt_raw + CASE WHEN size(tt_raw) > 1 THEN [joined_str] ELSE [] END AS targeted_therapy_string"));
     }
 }


### PR DESCRIPTION
Exposed the property survival_status to the participantOverview query so that values can be fetched for the Participant Details page.
[CTDC-2150](https://tracker.nci.nih.gov/browse/CTDC-2150)

Added Facet support for study files , Study files are connected to each participant and biospecimen to allow them to be filtered.
[CTDC-2140](https://tracker.nci.nih.gov/browse/CTDC-2140)

These were accomplished by linking Biospecimen, Participant, targeted therapies to the study files within the queries.
this is done by putting them inside the effective_subs variable. This change also took effect on tab_biospecimens,facets_widgets_counts, tab_participants , to link the main nodes so they will always display study files if filtered.

Also association for study , biospecimen, and participant were added to filter the index. 

All file queries are coming from the same index and to get the study files the study association has to be be applied and likewise the biospecimen and participant filter for the files associated with their nodes. This made filtering the files on the facet easier. 

