### PR TITLE
Simplify targeted_therapy aggregation and string

### DIFF
--- a/src/main/resources/graphql/crdc-ctdc-private-es.graphql
+++ b/src/main/resources/graphql/crdc-ctdc-private-es.graphql
@@ -1020,6 +1020,7 @@ type QueryType {
   ): [FileOverview]
 
   participant_data_files(
+    association: [String] = ["participant", "biospecimen"]
     participant_id: [String] = []
     study_short_name: [String] = []
     study_id: [String] = []

--- a/src/main/resources/yaml/es_indices_ctdc.yml
+++ b/src/main/resources/yaml/es_indices_ctdc.yml
@@ -829,23 +829,31 @@ Indices:
         RETURN head(collect(e)) AS e_latest
       }
 
-      CALL {
+        CALL {
         WITH sb
         OPTIONAL MATCH (sb)<-[:of_participant]-(tt:targeted_therapy)
         WITH [t IN COLLECT(tt.targeted_therapy)
           WHERE t IS NOT NULL AND trim(toString(t)) <> ''
-              | trim(toString(t))
+              | CASE
+                  WHEN toLower(trim(toString(t))) = 'not reported' THEN 'Not reported'
+                  ELSE trim(toString(t))
+                END
         ] AS ts,
         [r IN COLLECT(tt.best_response_to_targeted_therapy)
           WHERE r IS NOT NULL AND trim(toString(r)) <> ''
           | trim(toString(r))
         ] AS responses
-        WITH apoc.coll.toSet(ts) AS targeted_therapy,
-             apoc.coll.toSet(responses) AS best_response_to_targeted_therapy
-        RETURN targeted_therapy AS targeted_therapy,
-          best_response_to_targeted_therapy AS best_response_to_targeted_therapy,
+        WITH apoc.coll.toSet(ts) AS dedup, apoc.coll.toSet(responses) AS best_responses
+        WITH CASE
+          WHEN size(dedup) > 1 AND size([t IN dedup WHERE toLower(t) <> 'not reported']) > 0
+            THEN [t IN dedup WHERE toLower(t) <> 'not reported']
+          ELSE dedup
+        END AS cleaned_tt,
+        best_responses AS cleaned_responses
+        RETURN cleaned_tt AS targeted_therapy,
+          cleaned_responses AS best_response_to_targeted_therapy,
           CASE
-            WHEN size(targeted_therapy) > 0 THEN apoc.text.join(apoc.coll.sort(targeted_therapy), '|')
+            WHEN size(cleaned_tt) > 0 THEN apoc.text.join(apoc.coll.sort(cleaned_tt), '|')
             ELSE null
           END AS targeted_therapy_string
       }

--- a/src/main/resources/yaml/es_indices_ctdc.yml
+++ b/src/main/resources/yaml/es_indices_ctdc.yml
@@ -835,11 +835,11 @@ Indices:
         OPTIONAL MATCH (sb)<-[:of_participant]-(tt:targeted_therapy)
         WITH [t IN COLLECT(tt.targeted_therapy)
           WHERE t IS NOT NULL AND trim(toString(t)) <> ''
-              | toString(t)
+              | trim(toString(t))
         ] AS ts,
         [r IN COLLECT(tt.best_response_to_targeted_therapy)
-          WHERE r IS NOT NULL AND toString(r) <> ''
-          | toString(r)
+          WHERE r IS NOT NULL AND trim(toString(r)) <> ''
+          | trim(toString(r))
         ] AS responses
         WITH apoc.coll.toSet(ts) AS targeted_therapy,
              apoc.coll.toSet(responses) AS best_response_to_targeted_therapy

--- a/src/main/resources/yaml/es_indices_ctdc.yml
+++ b/src/main/resources/yaml/es_indices_ctdc.yml
@@ -584,24 +584,23 @@ Indices:
       WITH DISTINCT sb, study
 
       CALL {
-          WITH sb, study
-          OPTIONAL MATCH (sb)<-[:of_participant]-(tt:targeted_therapy)
-          WITH [x IN COLLECT({name: tt.targeted_therapy, id: tt.targeted_therapy_id}) 
-            WHERE x.name IS NOT NULL AND x.name <> ''] AS tt_items,
-            [r IN COLLECT(tt.best_response_to_targeted_therapy)
-          WHERE r IS NOT NULL AND toString(r) <> ''
-          | toString(r)
-            ] AS responses
-          WITH [x IN tt_items | {name: toLower(x.name), id: x.id}] AS normalized_items, responses
-          WITH apoc.map.groupBy(normalized_items, 'name') AS byName, responses
-          WITH [k IN keys(byName) |
-            {name: k, id: head([e IN byName[k] WHERE e.id IS NOT NULL | e.id])}] AS grouped, responses
-          WITH grouped,
-            [e IN grouped | apoc.text.capitalizeAll(e.name)] AS names,
-            responses
-          RETURN
-            names AS targeted_therapy,
-            [e IN grouped | e.id] AS targeted_therapy_id,
+        WITH sb, study
+        OPTIONAL MATCH (sb)<-[:of_participant]-(tt:targeted_therapy)
+        WITH [x IN COLLECT({name: tt.targeted_therapy, id: tt.targeted_therapy_id}) 
+          WHERE x.name IS NOT NULL AND trim(toString(x.name)) <> ''] AS tt_items,
+          [r IN COLLECT(tt.best_response_to_targeted_therapy)
+        WHERE r IS NOT NULL AND toString(r) <> ''
+        | toString(r)
+          ] AS responses
+        WITH apoc.map.groupBy(tt_items, 'name') AS byName, responses
+        WITH [k IN keys(byName) |
+          {name: k, id: head([e IN byName[k] WHERE e.id IS NOT NULL | e.id])}] AS grouped, responses
+        WITH grouped,
+          [e IN grouped | e.name] AS names,
+          responses
+        RETURN
+          names AS targeted_therapy,
+          [e IN grouped | e.id] AS targeted_therapy_id,
         CASE
           WHEN size(names) > 0 THEN apoc.text.join(apoc.coll.sort(names), '|')
           ELSE null

--- a/src/main/resources/yaml/es_indices_ctdc.yml
+++ b/src/main/resources/yaml/es_indices_ctdc.yml
@@ -602,7 +602,10 @@ Indices:
           RETURN
             names AS targeted_therapy,
             [e IN grouped | e.id] AS targeted_therapy_id,
-        apoc.text.join(apoc.coll.sort(names), '|') AS targeted_therapy_string,
+        CASE
+          WHEN size(names) > 0 THEN apoc.text.join(apoc.coll.sort(names), '|')
+          ELSE null
+        END AS targeted_therapy_string,
         apoc.coll.toSet(responses) AS best_response_to_targeted_therapy
       }
 
@@ -831,23 +834,21 @@ Indices:
         WITH sb
         OPTIONAL MATCH (sb)<-[:of_participant]-(tt:targeted_therapy)
         WITH [t IN COLLECT(tt.targeted_therapy)
-              WHERE t IS NOT NULL AND toString(t) <> ''
-              | apoc.text.capitalizeAll(toLower(toString(t)))
+          WHERE t IS NOT NULL AND trim(toString(t)) <> ''
+              | toString(t)
         ] AS ts,
         [r IN COLLECT(tt.best_response_to_targeted_therapy)
           WHERE r IS NOT NULL AND toString(r) <> ''
           | toString(r)
         ] AS responses
-        WITH apoc.coll.toSet(ts) AS dedup, apoc.coll.toSet(responses) AS best_responses
-        WITH CASE
-          WHEN size(dedup) > 1 AND size([t IN dedup WHERE t <> 'Not Reported']) > 0
-            THEN [t IN dedup WHERE t <> 'Not Reported']
-          ELSE dedup
-        END AS cleaned_tt,
-        best_responses AS cleaned_responses
-        RETURN cleaned_tt AS targeted_therapy,
-          cleaned_responses AS best_response_to_targeted_therapy,
-              apoc.text.join(apoc.coll.sort(cleaned_tt), '|') AS targeted_therapy_string
+        WITH apoc.coll.toSet(ts) AS targeted_therapy,
+             apoc.coll.toSet(responses) AS best_response_to_targeted_therapy
+        RETURN targeted_therapy AS targeted_therapy,
+          best_response_to_targeted_therapy AS best_response_to_targeted_therapy,
+          CASE
+            WHEN size(targeted_therapy) > 0 THEN apoc.text.join(apoc.coll.sort(targeted_therapy), '|')
+            ELSE null
+          END AS targeted_therapy_string
       }
 
       CALL {


### PR DESCRIPTION
Refactor Cypher in es_indices_ctdc.yml for targeted_therapy aggregation: trim and coerce values to strings, use apoc.coll.toSet for deduplication, and remove the previous capitalization and special-case filtering for 'Not Reported'. Also ensure targeted_therapy_string returns NULL (via a CASE) when there are no values instead of an empty string. This simplifies the query and yields more consistent output.

This removes No value for strings that are not natively '""'
So when targeted therapy string makes a null a "" it will turn it back into a null .

