### PR TITLE
include files directly associated with participants in study index

### DIFF
--- a/src/main/resources/yaml/es_indices_ctdc.yml
+++ b/src/main/resources/yaml/es_indices_ctdc.yml
@@ -90,7 +90,7 @@ Indices:
       optional MATCH (s)<-[:associated_with]-(al:associated_link)
       optional MATCH (p:publication)-[:of_study]->(s)
       optional MATCH (s)<-[:belongs_to]-(participant)
-      optional MATCH (participant)<-[*..2]-(parent)<--(f:file)
+      optional MATCH (participant)<-[*..2]-(f:file)
       optional MATCH (s)<-[:associated_with]-(df:file)
       WHERE NOT (df)--(:participant)
       AND NOT (df)-[:associated_with]->(:specimen)


### PR DESCRIPTION
[CTDC-2125](https://tracker.nci.nih.gov/browse/CTDC-2125)

- updates study index Cypher query participant file matching to avoid excluding files directly associated with participants, which leads to incorrect participant file counts on the Studies page.